### PR TITLE
Deploy using apex/up

### DIFF
--- a/.upignore
+++ b/.upignore
@@ -1,0 +1,6 @@
+.git
+cmd
+dist
+httpbin
+static
+Dockerfile

--- a/.upignore
+++ b/.upignore
@@ -1,6 +1,4 @@
-.git
-cmd
-dist
-httpbin
-static
-Dockerfile
+*
+!server
+!main
+!*.js

--- a/up.json
+++ b/up.json
@@ -1,0 +1,8 @@
+{
+    "name": "go-httpbin",
+    "profile": "up",
+    "hooks": {
+        "build": "GOOS=linux GOARCH=amd64 make && mv dist/go-httpbin server",
+        "clean": "rm -f server"
+    }
+}


### PR DESCRIPTION
Basic support for deploying via https://github.com/apex/up:

<img width="514" alt="screen shot 2017-08-12 at 8 16 52 pm" src="https://user-images.githubusercontent.com/57938/29245834-3156452a-7f9b-11e7-8c59-6fd9ae0d4ce8.png">

![screen shot 2017-08-12 at 8 17 44 pm](https://user-images.githubusercontent.com/57938/29245839-54a3117a-7f9b-11e7-8b37-1cdc47a67b41.png)

Currently deployed here:
https://wg7c5oygsl.execute-api.us-west-2.amazonaws.com/development/

This deployment doesn't actually work that well, because `go-httpbin` doesn't know how to handle the `/development` URL prefix that seems to be unavoidable until a custom domain is configured.

TODO:
- [x] custom domain w/ TLS
- [x] get rid of the `/{stage}` URL prefix (I _think_ [using a custom domain is required to make this happen]?)

[1]: http://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-custom-domains.html