### PR TITLE
Fix body parsing with longer form content-type headers

### DIFF
--- a/httpbin/helpers.go
+++ b/httpbin/helpers.go
@@ -107,7 +107,7 @@ func parseBody(w http.ResponseWriter, r *http.Request, resp *bodyResponse) error
 
 	ct := r.Header.Get("Content-Type")
 	switch {
-	case ct == "application/x-www-form-urlencoded":
+	case strings.HasPrefix(ct, "application/x-www-form-urlencoded"):
 		if err := r.ParseForm(); err != nil {
 			return err
 		}


### PR DESCRIPTION
This fixes `parseBody()` when the `Content-Type` header is something like `application/x-www-form-urlencoded; charset=utf-8`. 