### PR TITLE
Fix deflate encoded responses

### DIFF
--- a/httpbin/handlers.go
+++ b/httpbin/handlers.go
@@ -2,8 +2,8 @@ package httpbin
 
 import (
 	"bytes"
-	"compress/flate"
 	"compress/gzip"
+	"compress/zlib"
 	"encoding/json"
 	"fmt"
 	"math/rand"
@@ -109,7 +109,7 @@ func (h *HTTPBin) Deflate(w http.ResponseWriter, r *http.Request) {
 	body, _ := json.Marshal(resp)
 
 	buf := &bytes.Buffer{}
-	w2, _ := flate.NewWriter(buf, flate.DefaultCompression)
+	w2 := zlib.NewWriter(buf)
 	w2.Write(body)
 	w2.Close()
 

--- a/httpbin/handlers_test.go
+++ b/httpbin/handlers_test.go
@@ -3,8 +3,8 @@ package httpbin
 import (
 	"bufio"
 	"bytes"
-	"compress/flate"
 	"compress/gzip"
+	"compress/zlib"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -1261,7 +1261,10 @@ func TestDeflate(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	reader := flate.NewReader(w.Body)
+	reader, err := zlib.NewReader(w.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
 	body, err := ioutil.ReadAll(reader)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
RFC 2616 (HTTP/1.1) says in the ["3.5 Content Codings" section](https://tools.ietf.org/html/rfc2616#section-3.5) this about deflate:
> The "zlib" format defined in RFC 1950 [31] in combination with the "deflate" compression mechanism described in RFC 1951 [29].

The [zlib package](https://golang.org/pkg/compress/zlib/#pkg-overview) from Go's standard library imlpements RFC 1950 and it also [uses](https://golang.org/src/compress/zlib/writer.go#L15) the [flate package](https://golang.org/pkg/compress/flate/#pkg-overview) internally, which implements RFC 1951.

I'm not sure if you maintain httpbingo.org, but opening https://httpbingo.org/deflate with Firefox or Chrome produces an error, I assume because of this. For some reason `curl -v --compressed https://httpbingo.org/deflate` works though...
