### PR TITLE
Add support for HEAD and fix the OPTIONS HTTP method

### DIFF
--- a/httpbin/handlers.go
+++ b/httpbin/handlers.go
@@ -2,8 +2,8 @@ package httpbin
 
 import (
 	"bytes"
-	"compress/flate"
 	"compress/gzip"
+	"compress/zlib"
 	"encoding/json"
 	"fmt"
 	"math/rand"
@@ -109,7 +109,7 @@ func (h *HTTPBin) Deflate(w http.ResponseWriter, r *http.Request) {
 	body, _ := json.Marshal(resp)
 
 	buf := &bytes.Buffer{}
-	w2, _ := flate.NewWriter(buf, flate.DefaultCompression)
+	w2 := zlib.NewWriter(buf)
 	w2.Write(body)
 	w2.Close()
 

--- a/httpbin/handlers_test.go
+++ b/httpbin/handlers_test.go
@@ -3,8 +3,8 @@ package httpbin
 import (
 	"bufio"
 	"bytes"
-	"compress/flate"
 	"compress/gzip"
+	"compress/zlib"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -1261,7 +1261,10 @@ func TestDeflate(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	reader := flate.NewReader(w.Body)
+	reader, err := zlib.NewReader(w.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
 	body, err := ioutil.ReadAll(reader)
 	if err != nil {
 		t.Fatal(err)

--- a/httpbin/helpers.go
+++ b/httpbin/helpers.go
@@ -27,6 +27,16 @@ func getRequestHeaders(r *http.Request) http.Header {
 	return h
 }
 
+// Copies all headers from src to dst
+// From https://golang.org/src/net/http/httputil/reverseproxy.go#L109
+func copyHeader(dst, src http.Header) {
+	for k, vv := range src {
+		for _, v := range vv {
+			dst.Add(k, v)
+		}
+	}
+}
+
 func getOrigin(r *http.Request) string {
 	origin := r.Header.Get("X-Forwarded-For")
 	if origin == "" {

--- a/httpbin/httpbin.go
+++ b/httpbin/httpbin.go
@@ -175,6 +175,7 @@ func (h *HTTPBin) Handler() http.Handler {
 	handler = mux
 	handler = limitRequestSize(h.options.MaxMemory, handler)
 	handler = logger(handler)
+	handler = optionsAndHead(handler)
 	handler = cors(handler)
 	return handler
 }


### PR DESCRIPTION
Currently an `OPTIONS` request returns `405 Method Not Allowed` error and `HEAD` is not supported at all.

Edit: I just saw that this was branched from the [other PR](https://github.com/mccutchen/go-httpbin/pull/3), if you want I can cherry pick and create a new PR from `master`, but if you merge the other one first it should be fine as it is.