### PR TITLE
Add support for HEAD and fix the OPTIONS HTTP method

### DIFF
--- a/httpbin/helpers.go
+++ b/httpbin/helpers.go
@@ -27,6 +27,16 @@ func getRequestHeaders(r *http.Request) http.Header {
 	return h
 }
 
+// Copies all headers from src to dst
+// From https://golang.org/src/net/http/httputil/reverseproxy.go#L109
+func copyHeader(dst, src http.Header) {
+	for k, vv := range src {
+		for _, v := range vv {
+			dst.Add(k, v)
+		}
+	}
+}
+
 func getOrigin(r *http.Request) string {
 	origin := r.Header.Get("X-Forwarded-For")
 	if origin == "" {

--- a/httpbin/httpbin.go
+++ b/httpbin/httpbin.go
@@ -175,6 +175,7 @@ func (h *HTTPBin) Handler() http.Handler {
 	handler = mux
 	handler = limitRequestSize(h.options.MaxMemory, handler)
 	handler = logger(handler)
+	handler = optionsAndHead(handler)
 	handler = cors(handler)
 	return handler
 }

--- a/httpbin/httpbin.go
+++ b/httpbin/httpbin.go
@@ -174,8 +174,8 @@ func (h *HTTPBin) Handler() http.Handler {
 	var handler http.Handler
 	handler = mux
 	handler = limitRequestSize(h.options.MaxMemory, handler)
-	handler = logger(handler)
 	handler = optionsAndHead(handler)
+	handler = logger(handler)
 	handler = cors(handler)
 	return handler
 }

--- a/httpbin/httpbin.go
+++ b/httpbin/httpbin.go
@@ -174,9 +174,8 @@ func (h *HTTPBin) Handler() http.Handler {
 	var handler http.Handler
 	handler = mux
 	handler = limitRequestSize(h.options.MaxMemory, handler)
-	handler = optionsAndHead(handler)
+	handler = metaRequests(handler)
 	handler = logger(handler)
-	handler = cors(handler)
 	return handler
 }
 

--- a/httpbin/middleware.go
+++ b/httpbin/middleware.go
@@ -8,8 +8,16 @@ import (
 	"time"
 )
 
-func optionsAndHead(h http.Handler) http.Handler {
+func metaRequests(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		origin := r.Header.Get("Origin")
+		if origin == "" {
+			origin = "*"
+		}
+		respHeader := w.Header()
+		respHeader.Set("Access-Control-Allow-Origin", origin)
+		respHeader.Set("Access-Control-Allow-Credentials", "true")
+
 		switch r.Method {
 		case "OPTIONS":
 			w.Header().Set("Access-Control-Allow-Methods", "GET, POST, HEAD, PUT, DELETE, PATCH, OPTIONS")
@@ -28,20 +36,6 @@ func optionsAndHead(h http.Handler) http.Handler {
 		default:
 			h.ServeHTTP(w, r)
 		}
-	})
-}
-
-func cors(h http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		origin := r.Header.Get("Origin")
-		if origin == "" {
-			origin = "*"
-		}
-		respHeader := w.Header()
-		respHeader.Set("Access-Control-Allow-Origin", origin)
-		respHeader.Set("Access-Control-Allow-Credentials", "true")
-
-		h.ServeHTTP(w, r)
 	})
 }
 

--- a/httpbin/middleware.go
+++ b/httpbin/middleware.go
@@ -109,10 +109,11 @@ func (mw *metaResponseWriter) Size() int {
 
 func logger(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reqMethod, reqURI := r.Method, r.URL.RequestURI()
 		mw := &metaResponseWriter{w: w}
 		t := time.Now()
 		h.ServeHTTP(mw, r)
 		duration := time.Now().Sub(t)
-		log.Printf("status=%d method=%s uri=%q size=%d duration=%s", mw.Status(), r.Method, r.URL.RequestURI(), mw.Size(), duration)
+		log.Printf("status=%d method=%s uri=%q size=%d duration=%s", mw.Status(), reqMethod, reqURI, mw.Size(), duration)
 	})
 }


### PR DESCRIPTION
This is a rebased version of https://github.com/mccutchen/go-httpbin/pull/4 with a fixed middleware order.

At the moment `OPTIONS` requests return `405 Method Not Allowed` error and `HEAD` is not supported at all.