### PR TITLE
Deploy via `now` instead of `up`

### DIFF
--- a/now.json
+++ b/now.json
@@ -1,0 +1,8 @@
+{
+    "name": "go-httpbin",
+    "type": "docker",
+    "public": true,
+    "alias": [
+        "httpbingo.org"
+    ]
+}


### PR DESCRIPTION
Just experimenting with https://zeit.co/now as an alternative to https://up.docs.apex.sh/, mostly to get away from mysterious AWS API Gateway complexity/opacity/weirdness as described in https://github.com/mccutchen/go-httpbin/pull/3#issuecomment-375367129.