### PR TITLE
Support pluggable logger

### DIFF
--- a/cmd/go-httpbin/main.go
+++ b/cmd/go-httpbin/main.go
@@ -27,7 +27,7 @@ func main() {
 	flag.DurationVar(&maxDuration, "max-duration", httpbin.DefaultMaxDuration, "Maximum duration a response may take")
 	flag.Parse()
 
-	log.SetFlags(log.Ldate | log.Lmicroseconds | log.LUTC)
+	logger := log.New(os.Stderr, "", 0)
 
 	// Command line flags take precedence over environment vars, so we only
 	// check for environment vars if we have default values for our command
@@ -59,10 +59,13 @@ func main() {
 	}
 
 	h := httpbin.New(
+		httpbin.WithLogger(logger),
 		httpbin.WithMaxBodySize(maxBodySize),
 		httpbin.WithMaxDuration(maxDuration))
 
 	listenAddr := net.JoinHostPort("0.0.0.0", strconv.Itoa(port))
-	log.Printf("addr=%s", listenAddr)
-	log.Fatal(http.ListenAndServe(listenAddr, h.Handler()))
+
+	logger.Printf("go-httpbin listening on %s", listenAddr)
+
+	http.ListenAndServe(listenAddr, h.Handler())
 }

--- a/cmd/go-httpbin/main.go
+++ b/cmd/go-httpbin/main.go
@@ -27,8 +27,6 @@ func main() {
 	flag.DurationVar(&maxDuration, "max-duration", httpbin.DefaultMaxDuration, "Maximum duration a response may take")
 	flag.Parse()
 
-	logger := log.New(os.Stderr, "", 0)
-
 	// Command line flags take precedence over environment vars, so we only
 	// check for environment vars if we have default values for our command
 	// line flags.
@@ -58,14 +56,15 @@ func main() {
 		}
 	}
 
+	logger := log.New(os.Stderr, "", 0)
+
 	h := httpbin.New(
-		httpbin.WithLogger(logger),
 		httpbin.WithMaxBodySize(maxBodySize),
-		httpbin.WithMaxDuration(maxDuration))
+		httpbin.WithMaxDuration(maxDuration),
+		httpbin.WithObserver(httpbin.StdLogObserver(logger)),
+	)
 
 	listenAddr := net.JoinHostPort("0.0.0.0", strconv.Itoa(port))
-
 	logger.Printf("go-httpbin listening on %s", listenAddr)
-
 	http.ListenAndServe(listenAddr, h.Handler())
 }

--- a/httpbin/handlers_test.go
+++ b/httpbin/handlers_test.go
@@ -8,10 +8,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"reflect"
 	"strconv"
 	"strings"
@@ -24,7 +26,9 @@ const maxDuration time.Duration = 1 * time.Second
 
 var app = New(
 	WithMaxBodySize(maxBodySize),
-	WithMaxDuration(maxDuration))
+	WithMaxDuration(maxDuration),
+	WithObserver(StdLogObserver(log.New(os.Stderr, "", 0))),
+)
 
 var handler = app.Handler()
 

--- a/httpbin/httpbin_test.go
+++ b/httpbin/httpbin_test.go
@@ -1,6 +1,8 @@
 package httpbin
 
 import (
+	"log"
+	"os"
 	"testing"
 	"time"
 )
@@ -18,11 +20,16 @@ func TestNew(t *testing.T) {
 func TestNewOptions(t *testing.T) {
 	maxDuration := 1 * time.Second
 	maxBodySize := int64(1024)
+	logger := log.New(os.Stderr, "", log.LstdFlags)
 
 	h := New(
+		WithLogger(logger),
 		WithMaxBodySize(maxBodySize),
 		WithMaxDuration(maxDuration))
 
+	if h.Logger != logger {
+		t.Fatalf("expected Logger == %v, got %v", logger, h.Logger)
+	}
 	if h.MaxBodySize != maxBodySize {
 		t.Fatalf("expected MaxBodySize == %d, got %#v", maxBodySize, h.MaxBodySize)
 	}

--- a/httpbin/httpbin_test.go
+++ b/httpbin/httpbin_test.go
@@ -1,8 +1,9 @@
 package httpbin
 
 import (
-	"log"
-	"os"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 )
@@ -15,25 +16,51 @@ func TestNew(t *testing.T) {
 	if h.MaxDuration != DefaultMaxDuration {
 		t.Fatalf("expected default MaxDuration == %s, got %#v", DefaultMaxDuration, h.MaxDuration)
 	}
+	if h.Observer != nil {
+		t.Fatalf("expected default Observer == nil, got %#v", h.Observer)
+	}
 }
 
 func TestNewOptions(t *testing.T) {
 	maxDuration := 1 * time.Second
 	maxBodySize := int64(1024)
-	logger := log.New(os.Stderr, "", log.LstdFlags)
+	observer := func(_ Result) {}
 
 	h := New(
-		WithLogger(logger),
 		WithMaxBodySize(maxBodySize),
-		WithMaxDuration(maxDuration))
+		WithMaxDuration(maxDuration),
+		WithObserver(observer),
+	)
 
-	if h.Logger != logger {
-		t.Fatalf("expected Logger == %v, got %v", logger, h.Logger)
-	}
 	if h.MaxBodySize != maxBodySize {
 		t.Fatalf("expected MaxBodySize == %d, got %#v", maxBodySize, h.MaxBodySize)
 	}
 	if h.MaxDuration != maxDuration {
 		t.Fatalf("expected MaxDuration == %s, got %#v", maxDuration, h.MaxDuration)
+	}
+	if h.Observer == nil {
+		t.Fatalf("expected non-nil Observer")
+	}
+}
+
+func TestNewObserver(t *testing.T) {
+	expectedStatus := http.StatusTeapot
+
+	observed := false
+	observer := func(r Result) {
+		observed = true
+		if r.Status != expectedStatus {
+			t.Fatalf("expected result status = %d, got %d", expectedStatus, r.Status)
+		}
+	}
+
+	h := New(WithObserver(observer))
+
+	r, _ := http.NewRequest("GET", fmt.Sprintf("/status/%d", expectedStatus), nil)
+	w := httptest.NewRecorder()
+	h.Handler().ServeHTTP(w, r)
+
+	if observed == false {
+		t.Fatalf("observer never called")
 	}
 }

--- a/httpbin/middleware.go
+++ b/httpbin/middleware.go
@@ -2,6 +2,7 @@ package httpbin
 
 import (
 	"fmt"
+	"log"
 	"net/http"
 	"net/http/httptest"
 	"time"
@@ -68,12 +69,12 @@ func limitRequestSize(maxSize int64, h http.Handler) http.Handler {
 type metaResponseWriter struct {
 	w      http.ResponseWriter
 	status int
-	size   int
+	size   int64
 }
 
 func (mw *metaResponseWriter) Write(b []byte) (int, error) {
 	size, err := mw.w.Write(b)
-	mw.size += size
+	mw.size += int64(size)
 	return size, err
 }
 
@@ -98,20 +99,50 @@ func (mw *metaResponseWriter) Status() int {
 	return mw.status
 }
 
-func (mw *metaResponseWriter) Size() int {
+func (mw *metaResponseWriter) Size() int64 {
 	return mw.size
 }
 
-func logger(l Logger, h http.Handler) http.Handler {
+func observe(o Observer, h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		reqMethod, reqURI := r.Method, r.URL.RequestURI()
 		mw := &metaResponseWriter{w: w}
 		t := time.Now()
 		h.ServeHTTP(mw, r)
-		end := time.Now()
-		// non-obvious conversion from time.Duration to float64 milliseconds
-		// https://github.com/golang/go/issues/5491#issuecomment-66079585
-		duration := end.Sub(t).Seconds() * 1e3
-		l.Printf("time=%q status=%d method=%q uri=%q size_bytes=%d duration_ms=%0.02f", end.Format(loggerDateFormat), mw.Status(), reqMethod, reqURI, mw.Size(), duration)
+		o(Result{
+			Status:   mw.Status(),
+			Method:   r.Method,
+			URI:      r.URL.RequestURI(),
+			Size:     mw.Size(),
+			Duration: time.Now().Sub(t),
+		})
 	})
+}
+
+// Result is the result of handling a request, used for instrumentation
+type Result struct {
+	Status   int
+	Method   string
+	URI      string
+	Size     int64
+	Duration time.Duration
+}
+
+// Observer is a function that will be called with the details of a handled
+// request, which can be used for logging, instrumentation, etc
+type Observer func(result Result)
+
+// StdLogObserver creates an Observer that will log each request in structured
+// format using the given stdlib logger
+func StdLogObserver(l *log.Logger) Observer {
+	return func(result Result) {
+		l.Printf(
+			"time=%q status=%d method=%q uri=%q size_bytes=%d duration_ms=%0.02f",
+			time.Now().Format(loggerDateFormat),
+			result.Status,
+			result.Method,
+			result.URI,
+			result.Size,
+			result.Duration.Seconds()*1e3, // https://github.com/golang/go/issues/5491#issuecomment-66079585
+		)
+	}
 }

--- a/httpbin/middleware.go
+++ b/httpbin/middleware.go
@@ -8,8 +8,6 @@ import (
 	"time"
 )
 
-const loggerDateFormat string = "2006-01-02T15:04:05.9999"
-
 func metaRequests(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		origin := r.Header.Get("Origin")
@@ -134,10 +132,14 @@ type Observer func(result Result)
 // StdLogObserver creates an Observer that will log each request in structured
 // format using the given stdlib logger
 func StdLogObserver(l *log.Logger) Observer {
+	const (
+		logFmt  = "time=%q status=%d method=%q uri=%q size_bytes=%d duration_ms=%0.02f"
+		dateFmt = "2006-01-02T15:04:05.9999"
+	)
 	return func(result Result) {
 		l.Printf(
-			"time=%q status=%d method=%q uri=%q size_bytes=%d duration_ms=%0.02f",
-			time.Now().Format(loggerDateFormat),
+			logFmt,
+			time.Now().Format(dateFmt),
 			result.Status,
 			result.Method,
 			result.URI,


### PR DESCRIPTION
This change allows users to specify their own logger for an `HTTPBin` instance, as long as it implements this minimal interface (which matches [the stdlib's `log.Logger`][1]):

```go
// Logger is a minimal logging interface
type Logger interface {
	Printf(format string, v ...interface{})
}
```

When using go-httpbin as a library (e.g. for unit tests), the default logger now _silently discards all messages_.

The `go-httpbin` binary & Docker container, on the other hand, will generate log messages like so:

```
./dist/go-httpbin
go-httpbin listening on 0.0.0.0:8080
time="2019-01-14T17:04:54.5177" status=200 method="GET" uri="/" size_bytes=11271 duration_ms=0.55
time="2019-01-14T17:04:59.048" status=418 method="GET" uri="/status/418" size_bytes=13 duration_ms=0.20
time="2019-01-14T17:05:03.1649" status=302 method="GET" uri="/redirect/6" size_bytes=0 duration_ms=0.04
time="2019-01-14T17:05:03.1754" status=302 method="GET" uri="/relative-redirect/5" size_bytes=0 duration_ms=0.02
time="2019-01-14T17:05:03.1826" status=302 method="GET" uri="/relative-redirect/4" size_bytes=0 duration_ms=0.03
time="2019-01-14T17:05:03.1908" status=302 method="GET" uri="/relative-redirect/3" size_bytes=0 duration_ms=0.02
time="2019-01-14T17:05:03.1961" status=302 method="GET" uri="/relative-redirect/2" size_bytes=0 duration_ms=0.02
time="2019-01-14T17:05:03.2042" status=302 method="GET" uri="/relative-redirect/1" size_bytes=0 duration_ms=0.03
time="2019-01-14T17:05:03.2113" status=200 method="GET" uri="/get" size_bytes=531 duration_ms=0.14
```

Fixes #9.

[1]: https://golang.org/pkg/log/#Logger.Printf