### PR TITLE
Add support for /uuid

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ go:
   - '1.9'
   - '1.10'
   - '1.11'
+go_import_path: github.com/mccutchen/go-httpbin
 script:
   - make lint
   - make test

--- a/cmd/go-httpbin/main.go
+++ b/cmd/go-httpbin/main.go
@@ -89,18 +89,22 @@ func main() {
 		Handler: h.Handler(),
 	}
 
+	var listenErr error
 	if httpsCertFile != "" && httpsKeyFile != "" {
 		cert, err := tls.LoadX509KeyPair(httpsCertFile, httpsKeyFile)
 		if err != nil {
-			log.Fatal("Failed to generate https key pair: ", err)
+			logger.Fatal("Failed to generate https key pair: ", err)
 		}
 		server.TLSConfig = &tls.Config{
 			Certificates: []tls.Certificate{cert},
 		}
 		logger.Printf("go-httpbin listening on https://%s", listenAddr)
-		server.ListenAndServeTLS("", "")
+		listenErr = server.ListenAndServeTLS("", "")
 	} else {
 		logger.Printf("go-httpbin listening on http://%s", listenAddr)
-		server.ListenAndServe()
+		listenErr = server.ListenAndServe()
+	}
+	if listenErr != nil {
+		logger.Fatalf("Failed to listen: %s", listenErr)
 	}
 }

--- a/httpbin/handlers.go
+++ b/httpbin/handlers.go
@@ -895,3 +895,16 @@ func (h *HTTPBin) DigestAuth(w http.ResponseWriter, r *http.Request) {
 	})
 	writeJSON(w, resp, http.StatusOK)
 }
+
+// UUID responds with a generated UUID
+func (h *HTTPBin) UUID(w http.ResponseWriter, r *http.Request) {
+	u, err := uuidv4()
+	if err != nil {
+		http.Error(w, fmt.Sprintf("Failed to generate uuid: %s", err), http.StatusInternalServerError)
+		return
+	}
+	resp, _ := json.Marshal(&uuidResponse{
+		UUID: u,
+	})
+	writeJSON(w, resp, http.StatusOK)
+}

--- a/httpbin/helpers.go
+++ b/httpbin/helpers.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"math/rand"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -229,4 +230,16 @@ func (s *syntheticByteStream) Seek(offset int64, whence int) (int64, error) {
 func sha1hash(input string) string {
 	h := sha1.New()
 	return fmt.Sprintf("%x", h.Sum([]byte(input)))
+}
+
+func uuidv4() (string, error) {
+	buff := make([]byte, 16)
+	_, err := rand.Read(buff[:])
+	if err != nil {
+		return "", err
+	}
+	buff[6] = (buff[6] & 0x0f) | 0x40 // Version 4
+	buff[8] = (buff[8] & 0x3f) | 0x80 // Variant 10
+	uuid := fmt.Sprintf("%x-%x-%x-%x-%x", buff[0:4], buff[4:6], buff[6:8], buff[8:10], buff[10:])
+	return uuid, nil
 }

--- a/httpbin/httpbin.go
+++ b/httpbin/httpbin.go
@@ -76,6 +76,10 @@ type streamResponse struct {
 	URL     string      `json:"url"`
 }
 
+type uuidResponse struct {
+	UUID string `json:"uuid"`
+}
+
 // HTTPBin contains the business logic
 type HTTPBin struct {
 	// Max size of an incoming request generated response body, in bytes
@@ -147,6 +151,8 @@ func (h *HTTPBin) Handler() http.Handler {
 	mux.HandleFunc("/image", h.ImageAccept)
 	mux.HandleFunc("/image/", h.Image)
 	mux.HandleFunc("/xml", h.XML)
+
+	mux.HandleFunc("/uuid", h.UUID)
 
 	// existing httpbin endpoints that we do not support
 	mux.HandleFunc("/brotli", notImplementedHandler)


### PR DESCRIPTION
- Added code and test cases for /uuid endpoint
- Updated httpbin.go to handle ListenAndServe errors - useful because in the current state, the code silently fails in case the server is rerun with the same host and port combination.  