### PR TITLE
Get code coverage back up

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A reasonably complete and well-tested golang port of [Kenneth Reitz][kr]'s
 
 [![GoDoc](https://godoc.org/github.com/mccutchen/go-httpbin?status.svg)](https://godoc.org/github.com/mccutchen/go-httpbin)
 [![Build Status](https://travis-ci.org/mccutchen/go-httpbin.svg?branch=master)](http://travis-ci.org/mccutchen/go-httpbin)
-[![Coverage](http://gocover.io/_badge/github.com/mccutchen/go-httpbin/httpbin?0)](http://gocover.io/github.com/mccutchen/go-httpbin/httpbin)
+[![Coverage](https://codecov.io/gh/mccutchen/go-httpbin/branch/master/graph/badge.svg)](https://codecov.io/gh/mccutchen/go-httpbin)
 
 
 ## Usage

--- a/httpbin/handlers.go
+++ b/httpbin/handlers.go
@@ -898,13 +898,8 @@ func (h *HTTPBin) DigestAuth(w http.ResponseWriter, r *http.Request) {
 
 // UUID - responds with a generated UUID
 func (h *HTTPBin) UUID(w http.ResponseWriter, r *http.Request) {
-	u, err := uuidv4()
-	if err != nil {
-		http.Error(w, fmt.Sprintf("Failed to generate uuid: %s", err), http.StatusInternalServerError)
-		return
-	}
 	resp, _ := json.Marshal(&uuidResponse{
-		UUID: u,
+		UUID: uuidv4(),
 	})
 	writeJSON(w, resp, http.StatusOK)
 }

--- a/httpbin/handlers_test.go
+++ b/httpbin/handlers_test.go
@@ -54,7 +54,7 @@ func assertContentType(t *testing.T, w *httptest.ResponseRecorder, contentType s
 
 func assertBodyContains(t *testing.T, w *httptest.ResponseRecorder, needle string) {
 	if !strings.Contains(w.Body.String(), needle) {
-		t.Fatalf("expected string %v in body", needle)
+		t.Fatalf("expected string %q in body %q", needle, w.Body.String())
 	}
 }
 
@@ -2253,6 +2253,22 @@ func TestBase64(t *testing.T) {
 		{
 			"/base64/decode/" + randStringBytes(Base64MaxLen+1),
 			"Cannot handle input",
+		},
+		{
+			"/base64/",
+			"No input data",
+		},
+		{
+			"/base64/decode/",
+			"No input data",
+		},
+		{
+			"/base64/decode/dmFsaWRfYmFzZTY0X2VuY29kZWRfc3RyaW5n/extra",
+			"Invalid URL",
+		},
+		{
+			"/base64/unknown/dmFsaWRfYmFzZTY0X2VuY29kZWRfc3RyaW5n",
+			"Invalid operation: unknown",
 		},
 	}
 

--- a/httpbin/helpers.go
+++ b/httpbin/helpers.go
@@ -236,16 +236,15 @@ func sha1hash(input string) string {
 	return fmt.Sprintf("%x", h.Sum([]byte(input)))
 }
 
-func uuidv4() (string, error) {
+func uuidv4() string {
 	buff := make([]byte, 16)
 	_, err := rand.Read(buff[:])
 	if err != nil {
-		return "", err
+		panic(err)
 	}
 	buff[6] = (buff[6] & 0x0f) | 0x40 // Version 4
 	buff[8] = (buff[8] & 0x3f) | 0x80 // Variant 10
-	uuid := fmt.Sprintf("%x-%x-%x-%x-%x", buff[0:4], buff[4:6], buff[6:8], buff[8:10], buff[10:])
-	return uuid, nil
+	return fmt.Sprintf("%x-%x-%x-%x-%x", buff[0:4], buff[4:6], buff[6:8], buff[8:10], buff[10:])
 }
 
 // base64Helper - describes the base64 operation (encode|decode) and input data


### PR DESCRIPTION
Two things here:
 1. Test all base64 error cases
 2. Just let `uuidv4()` panic if it can't read enough random data (which is a legitimately exceptional circumstance)