### PR TITLE
Shut down gracefully

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 ---
 language: go
 go:
-  - '1.10'
   - '1.11'
   - '1.12'
+  - '1.13'
 
 script:
   - make lint

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.11
+FROM golang:1.13
 
 WORKDIR /go/src/github.com/mccutchen/go-httpbin
 

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,9 @@
 # go-httpbin:latest image use `make imagepush VERSION=latest)`
 VERSION        ?= $(shell git rev-parse --short HEAD)
 
-# Override this to deploy to a different App Engine project
+# Override these values to deploy to a different App Engine project
 GCLOUD_PROJECT ?= httpbingo
+GCLOUD_ACCOUNT ?= mccutchen@gmail.com
 
 # Built binaries will be placed here
 DIST_PATH  	  ?= dist
@@ -72,10 +73,10 @@ lint: $(GOLINT)
 # deploy & run locally
 # =============================================================================
 deploy: build
-	gcloud app deploy --quiet --project=$(GCLOUD_PROJECT) --version=$(VERSION) --promote
+	gcloud --account=$(GCLOUD_ACCOUNT) app deploy --quiet --project=$(GCLOUD_PROJECT) --version=$(VERSION) --promote
 
 stagedeploy: build
-	gcloud app deploy --quiet --project=$(GCLOUD_PROJECT) --version=$(VERSION) --no-promote
+	gcloud --account=$(GCLOUD_ACCOUNT) app deploy --quiet --project=$(GCLOUD_PROJECT) --version=$(VERSION) --no-promote
 
 run: build
 	$(DIST_PATH)/go-httpbin


### PR DESCRIPTION
Ensure that go-httpbin allows any in-flight requests to finish before shutting down.

I'm not sure how best to unit test this, so for now I've just tested it manually like so:

1. In one shell, `make run`
2. In another shell, `curl -s -v localhost:8080/delay/10 >/dev/null` to make a 10 second request
3. In a third shell, `kill -s TERM $(ps aux | grep go-httpbin | grep -v grep | awk '{print $2}')` to tell the server to shut down

This results in these logs from the server, showing that the request was allowed to finish before it exited:

```
time="2019-10-03T08:22:28.5216" msg="received signal terminated, shutdown started"
time="2019-10-03T08:22:35.2511" status=200 method="GET" uri="/delay/10" size_bytes=204 duration_ms=10000.60
time="2019-10-03T08:22:35.5227" msg="shutdown finished"
```

and the `curl` command did get back a 200 OK response:

```
$ curl -s -v localhost:8080/delay/10 >/dev/null
*   Trying ::1...
* TCP_NODELAY set
* Connected to localhost (::1) port 8080 (#0)
> GET /delay/10 HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.54.0
> Accept: */*
> 
< HTTP/1.1 200 OK
< Access-Control-Allow-Credentials: true
< Access-Control-Allow-Origin: *
< Content-Length: 204
< Content-Type: application/json; encoding=utf-8
< Date: Thu, 03 Oct 2019 15:22:35 GMT
< Connection: close
< 
{ [204 bytes data]
* Closing connection 0
```