### PR TITLE
- 1 fix and allow faster "stream-bytes" endpoint

### DIFF
--- a/httpbin/handlers.go
+++ b/httpbin/handlers.go
@@ -750,9 +750,9 @@ func (h *HTTPBin) handleBytes(w http.ResponseWriter, r *http.Request, streaming 
 	
 	f := w.(http.Flusher)
 	// send the buffer as many times as needed
-	var num_chunk = numBytes / chunkSize
-	// fmt.Println("num_chunk :", num_chunk)
-	for i = 0; i < num_chunk; i++ {
+	var numChunk = numBytes / chunkSize
+	// fmt.Println("numChunk :", numChunk)
+	for i = 0; i < numChunk; i++ {
 		w.Write(chunk)
 		f.Flush()		
 	}

--- a/httpbin/handlers.go
+++ b/httpbin/handlers.go
@@ -683,7 +683,7 @@ func (h *HTTPBin) handleBytes(w http.ResponseWriter, r *http.Request, streaming 
 		return
 	}
 
-	numBytes, err := strconv.ParseInt(parts[2], 10, 64);
+	numBytes, err := strconv.ParseInt(parts[2], 10, 64)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
@@ -705,11 +705,11 @@ func (h *HTTPBin) handleBytes(w http.ResponseWriter, r *http.Request, streaming 
 				http.Error(w, err.Error(), http.StatusBadRequest)
 				return
 			}
-			if (chunkSize < 1) {
-				chunkSize = 1 
+			if chunkSize < 1 {
+				chunkSize = 1
 			}
 			// todo- for now we limit chunkSize to maxBodySize. do we a new cmd line parameter for max chunk size ?
-			if (chunkSize > h.MaxBodySize) {
+			if chunkSize > h.MaxBodySize {
 				//fmt.Println("chunk is too big {}", chunkSize)
 				chunkSize = h.MaxBodySize
 			}
@@ -737,7 +737,7 @@ func (h *HTTPBin) handleBytes(w http.ResponseWriter, r *http.Request, streaming 
 	rng := rand.New(src)
 
 	w.Header().Set("Content-Type", "application/octet-stream")
-	w.Header().Set("Content-Length", strconv.FormatInt(numBytes,10))
+	w.Header().Set("Content-Length", strconv.FormatInt(numBytes, 10))
 
 	w.WriteHeader(http.StatusOK)
 
@@ -747,20 +747,20 @@ func (h *HTTPBin) handleBytes(w http.ResponseWriter, r *http.Request, streaming 
 	for i = 0; i < chunkSize; i++ {
 		chunk = append(chunk, byte(rng.Intn(256)))
 	}
-	
+
 	f := w.(http.Flusher)
 	// send the buffer as many times as needed
 	var numChunk = numBytes / chunkSize
 	// fmt.Println("numChunk :", numChunk)
 	for i = 0; i < numChunk; i++ {
 		w.Write(chunk)
-		f.Flush()		
+		f.Flush()
 	}
 
-	// send the modulo is any 
+	// send the modulo is any
 	// fmt.Println("modulo :", numBytes % chunkSize)
-	if (numBytes % chunkSize > 0) {
-		w.Write(chunk[:numBytes % chunkSize])
+	if numBytes%chunkSize > 0 {
+		w.Write(chunk[:numBytes%chunkSize])
 		f.Flush()
 	}
 	chunk = nil

--- a/httpbin/handlers.go
+++ b/httpbin/handlers.go
@@ -705,6 +705,9 @@ func (h *HTTPBin) handleBytes(w http.ResponseWriter, r *http.Request, streaming 
 				http.Error(w, err.Error(), http.StatusBadRequest)
 				return
 			}
+			if (chunkSize < 1) {
+				chunkSize = 1 
+			}
 			// todo- for now we limit chunkSize to maxBodySize. do we a new cmd line parameter for max chunk size ?
 			if (chunkSize > h.MaxBodySize) {
 				//fmt.Println("chunk is too big {}", chunkSize)
@@ -714,6 +717,9 @@ func (h *HTTPBin) handleBytes(w http.ResponseWriter, r *http.Request, streaming 
 			chunkSize = 10 * 1024 // todo: move this in a parameter/const
 		}
 	}
+
+	// fmt.Println("numBytes {}", numBytes)
+	// fmt.Println("chunkSize {}", chunkSize)
 
 	var seed int64
 	rawSeed := r.URL.Query().Get("seed")
@@ -745,14 +751,15 @@ func (h *HTTPBin) handleBytes(w http.ResponseWriter, r *http.Request, streaming 
 	f := w.(http.Flusher)
 	// send the buffer as many times as needed
 	var num_chunk = numBytes / chunkSize
+	// fmt.Println("num_chunk :", num_chunk)
 	for i = 0; i < num_chunk; i++ {
 		w.Write(chunk)
 		f.Flush()		
 	}
 
-	// send the modulo is any (or full body if not streaming)
+	// send the modulo is any 
+	// fmt.Println("modulo :", numBytes % chunkSize)
 	if (numBytes % chunkSize > 0) {
-		//fmt.Println(numBytes % chunkSize)
 		w.Write(chunk[:numBytes % chunkSize])
 		f.Flush()
 	}

--- a/httpbin/handlers_test.go
+++ b/httpbin/handlers_test.go
@@ -1989,6 +1989,9 @@ func TestStreamBytes(t *testing.T) {
 
 		// as is negative chunk size
 		{"/stream-bytes/256?chunk_size=-10", 256},
+
+		// way too large chunk size is okay
+		{fmt.Sprintf("/stream-bytes/256?chunk_size=%d", maxBodySize+20), 256},
 	}
 	for _, test := range okTests {
 		t.Run("ok"+test.url, func(t *testing.T) {


### PR DESCRIPTION
- fix: original code limits stream-bytes & bytes endpoints to 100 * 1024 instead of MaxBodySize
- enhancement: stream-bytes sends the same chunk over and over instead of computing all chunks. greatly improve performance on high speed networking (tested a 10Gbps ok). 
- bug/todo:  -max-duration is not enforced 
- enh/todo: parse units for argument (10KB, 5MB, 12GB, for instance) using https://github.com/alecthomas/units/issues or equivalent.