### PR TITLE
static/index.html: change links from httpbin.org to httpbingo.org

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -117,17 +117,17 @@
 
 <h2 id="EXAMPLES">EXAMPLES</h2>
 
-<h3 id="-curl-http-httpbin-org-ip">$ curl http://httpbin.org/ip</h3>
+<h3 id="-curl-http-httpbin-org-ip">$ curl https://httpbingo.org/ip</h3>
 
 <pre><code>{"origin": "24.127.96.129"}
 </code></pre>
 
-<h3 id="-curl-http-httpbin-org-user-agent">$ curl http://httpbin.org/user-agent</h3>
+<h3 id="-curl-http-httpbin-org-user-agent">$ curl https://httpbingo.org/user-agent</h3>
 
 <pre><code>{"user-agent": "curl/7.19.7 (universal-apple-darwin10.0) libcurl/7.19.7 OpenSSL/0.9.8l zlib/1.2.3"}
 </code></pre>
 
-<h3 id="-curl-http-httpbin-org-get">$ curl http://httpbin.org/get</h3>
+<h3 id="-curl-http-httpbin-org-get">$ curl https://httpbingo.org/get</h3>
 
 <pre><code>{
    "args": {},
@@ -140,11 +140,11 @@
       "User-Agent": "curl/7.19.7 (universal-apple-darwin10.0) libcurl/7.19.7 OpenSSL/0.9.8l zlib/1.2.3"
    },
    "origin": "24.127.96.129",
-   "url": "http://httpbin.org/get"
+   "url": "https://httpbingo.org/get"
 }
 </code></pre>
 
-<h3 id="-curl-I-http-httpbin-org-status-418">$ curl -I http://httpbin.org/status/418</h3>
+<h3 id="-curl-I-http-httpbin-org-status-418">$ curl -I https://httpbingo.org/status/418</h3>
 
 <pre><code>HTTP/1.1 418 I'M A TEAPOT
 Server: nginx/0.7.67
@@ -177,7 +177,7 @@ Content-Length: 135
     "show_env": "1"
   },
   "origin": "109.60.101.240",
-  "url": "http://httpbin.org/get?show_env=1"
+  "url": "https://httpbingo.org/get?show_env=1"
 }
 </code></pre>
 


### PR DESCRIPTION
Was a little confused when the fork's home page contained links to the original version of `httpbin`, not sure if these changes are in the right place, I was looking for a `/docs` or `/html` folder. 