### PR TITLE
Allow serving non-index pages via plain HTTP (fixes #35)

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -3,9 +3,14 @@ runtime: go112
 
 main: ./cmd/go_httpbin
 
-# redirect everything to https
 handlers:
-  - url: /.*
+  # Always redirect index requests to https
+  - url: /
     script: auto
     secure: always
     redirect_http_response_code: 301
+
+  # Allow requests for any other resources via either http or https
+  - url: /.+
+    script: auto
+    secure: optional

--- a/app.yaml
+++ b/app.yaml
@@ -1,5 +1,5 @@
 ---
-runtime: go112
+runtime: go113
 
 main: ./cmd/go_httpbin
 


### PR DESCRIPTION
Per #35, httpbingo.org requiring https for all requests actually reduces its utility as a general purpose http testing tool.  Here we tweak the App Engine deployment configuration to require https only for requests to the index page, but not to any other resources.

My thought is that it's still worthwhile to use https by default, especially for users who end up at httpbingo.org in a web browser, but we'll see whether this actually works the way I'm hoping it will.