### PR TITLE
Deploy to Google Cloud Run

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM golang:1.13
+FROM golang:1.15
 
 WORKDIR /go/src/github.com/mccutchen/go-httpbin
 
-COPY Makefile .
-RUN make deps
+# Manually implement the subset of `make deps` we need to build the image
+RUN cd /tmp && go get -u github.com/kevinburke/go-bindata/...
 
 COPY . .
 RUN make build buildtests

--- a/bin/gcloud
+++ b/bin/gcloud
@@ -6,10 +6,12 @@
 # Adapted from this helpful blog post:
 # https://blog.scottlowe.org/2018/09/13/running-gcloud-cli-in-a-docker-container/
 
+GCLOUD_SDK_TAG="312.0.0"
+
 exec docker run \
-    --rm \
-    -ti \
+    --rm -it \
     --workdir /code \
     -v $PWD:/code \
     -v $HOME/.config/gcloud:/root/.config/gcloud \
-    google/cloud-sdk gcloud $*
+    google/cloud-sdk:$GCLOUD_SDK_TAG \
+    gcloud $*


### PR DESCRIPTION
Move from Google's managed App Engine platform to their managed Cloud Run platform, to unbreak the endpoints that stream responses. Fixes #40 and #41.

https://httpbingo.org is now served from Cloud Run (pending DNS propagation).  This curl command should confirm whether it's now working as expected:

```
curl 'https://httpbingo.org/drip?numbytes=10&duration=10' --no-buffer
```

Still TODO (but maybe in a follow-up):
- [ ] Update GitHub Actions continuous deployment workflows to work with Cloud Run