### PR TITLE
Fix handling of HEAD requests for streaming responses

### DIFF
--- a/httpbin/handlers_test.go
+++ b/httpbin/handlers_test.go
@@ -1604,6 +1604,29 @@ func TestDrip(t *testing.T) {
 			assertStatusCode(t, w, test.code)
 		})
 	}
+
+	t.Run("ensure HEAD request works with streaming responses", func(t *testing.T) {
+		srv := httptest.NewServer(handler)
+		defer srv.Close()
+
+		resp, err := http.Head(srv.URL + "/drip?duration=900ms&delay=100ms")
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		defer resp.Body.Close()
+
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatalf("error reading response body: %s", err)
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("expected HTTP 200 OK rsponse, got %d", resp.StatusCode)
+		}
+		if bodySize := len(body); bodySize > 0 {
+			t.Fatalf("expected empty body from HEAD request, bot: %s", string(body))
+		}
+	})
 }
 
 func TestRange(t *testing.T) {

--- a/httpbin/middleware.go
+++ b/httpbin/middleware.go
@@ -61,7 +61,7 @@ func limitRequestSize(maxSize int64, h http.Handler) http.Handler {
 // headResponseWriter implements http.ResponseWriter in order to discard the
 // body of the response
 type headResponseWriter struct {
-	http.ResponseWriter
+	*metaResponseWriter
 }
 
 func (hw *headResponseWriter) Write(b []byte) (int, error) {
@@ -72,7 +72,7 @@ func (hw *headResponseWriter) Write(b []byte) (int, error) {
 func autohead(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == "HEAD" {
-			w = &headResponseWriter{w}
+			w = &headResponseWriter{&metaResponseWriter{w: w}}
 		}
 		h.ServeHTTP(w, r)
 	})


### PR DESCRIPTION
This fixes a panic caused by `HEAD` requests to endpoints that stream responses (e.g. `/drip`, `/stream`, etc):

```
2020/09/30 15: 59:21 http: panic serving 169.254.8.129:57237: interface conversion: *httpbin.headResponseWriter is not http.Flusher: missing method Flush

        at net/http.(*conn).serve.func1 (server.go:1801)
        at panic (/usr/local/go/src/runtime/panic.go:975)
        at github.com/mccutchen/go-httpbin/httpbin.(*HTTPBin).Drip (handlers.go:543)
        at net/http.HandlerFunc.ServeHTTP (server.go:2042)
        at net/http.(*ServeMux).ServeHTTP (server.go:2417)
        at github.com/mccutchen/go-httpbin/httpbin.limitRequestSize.func1 (middleware.go:57)
        at net/http.HandlerFunc.ServeHTTP (server.go:2042)
        at github.com/mccutchen/go-httpbin/httpbin.preflight.func1 (middleware.go:30)
        at net/http.HandlerFunc.ServeHTTP (server.go:2042)
        at github.com/mccutchen/go-httpbin/httpbin.autohead.func1 (middleware.go:77)
        at net/http.HandlerFunc.ServeHTTP (server.go:2042)
        at github.com/mccutchen/go-httpbin/httpbin.observe.func1 (middleware.go:124)
        at net/http.HandlerFunc.ServeHTTP (server.go:2042)
        at net/http.serverHandler.ServeHTTP (server.go:2843)
        at net/http.(*conn).serve (server.go:1925)
```