### PR TITLE
Better redirects

### DIFF
--- a/httpbin/handlers.go
+++ b/httpbin/handlers.go
@@ -172,12 +172,26 @@ func (h *HTTPBin) Status(w http.ResponseWriter, r *http.Request) {
 		"accept":  acceptedMediaTypes,
 	})
 
+	http308body := []byte(`<!doctype html>
+<head>
+<title>Permanent Redirect</title>
+</head>
+<body>Permanently redirected to <a href="/image/jpeg">/image/jpeg</a>
+</body>
+</html>`)
+
 	specialCases := map[int]*statusCase{
 		301: redirectHeaders,
 		302: redirectHeaders,
 		303: redirectHeaders,
 		305: redirectHeaders,
 		307: redirectHeaders,
+		308: {
+			body: http308body,
+			headers: map[string]string{
+				"Location": "/image/jpeg",
+			},
+		},
 		401: {
 			headers: map[string]string{
 				"WWW-Authenticate": `Basic realm="Fake Realm"`,

--- a/httpbin/handlers.go
+++ b/httpbin/handlers.go
@@ -172,6 +172,18 @@ func (h *HTTPBin) Status(w http.ResponseWriter, r *http.Request) {
 		"accept":  acceptedMediaTypes,
 	})
 
+	http300body := []byte(`<!doctype html>
+<head>
+<title>Multiple Choices</title>
+</head>
+<body>
+<ul>
+<li><a href="/image/jpeg">/image/jpeg</a></li>
+<li><a href="/image/png">/image/png</a></li>
+<li><a href="/image/svg">/image/svg</a></li>
+</body>
+</html>`)
+
 	http308body := []byte(`<!doctype html>
 <head>
 <title>Permanent Redirect</title>
@@ -181,6 +193,12 @@ func (h *HTTPBin) Status(w http.ResponseWriter, r *http.Request) {
 </html>`)
 
 	specialCases := map[int]*statusCase{
+		300: {
+			body: http300body,
+			headers: map[string]string{
+				"Location": "/image/jpeg",
+			},
+		},
 		301: redirectHeaders,
 		302: redirectHeaders,
 		303: redirectHeaders,

--- a/httpbin/handlers_test.go
+++ b/httpbin/handlers_test.go
@@ -708,6 +708,17 @@ func TestStatus(t *testing.T) {
 		body    string
 	}{
 		{200, nil, ""},
+		{300, map[string]string{"Location": "/image/jpeg"}, `<!doctype html>
+<head>
+<title>Multiple Choices</title>
+</head>
+<body>
+<ul>
+<li><a href="/image/jpeg">/image/jpeg</a></li>
+<li><a href="/image/png">/image/png</a></li>
+<li><a href="/image/svg">/image/svg</a></li>
+</body>
+</html>`},
 		{301, redirectHeaders, ""},
 		{302, redirectHeaders, ""},
 		{308, map[string]string{"Location": "/image/jpeg"}, `<!doctype html>

--- a/httpbin/handlers_test.go
+++ b/httpbin/handlers_test.go
@@ -710,6 +710,13 @@ func TestStatus(t *testing.T) {
 		{200, nil, ""},
 		{301, redirectHeaders, ""},
 		{302, redirectHeaders, ""},
+		{308, map[string]string{"Location": "/image/jpeg"}, `<!doctype html>
+<head>
+<title>Permanent Redirect</title>
+</head>
+<body>Permanently redirected to <a href="/image/jpeg">/image/jpeg</a>
+</body>
+</html>`},
 		{401, unauthorizedHeaders, ""},
 		{418, nil, "I'm a teapot!"},
 	}


### PR DESCRIPTION
This fixes the `/status` endpoint's handling of [300 Multiple Choice](https://httpstatuses.com/300) and [308 Permanent Redirect](https://httpstatuses.com/308) responses, per @cbeamond's reports in #46 and #47.