### PR TITLE
Update /ip endpoint to return single origin IP

### DIFF
--- a/httpbin/helpers.go
+++ b/httpbin/helpers.go
@@ -33,11 +33,12 @@ func getRequestHeaders(r *http.Request) http.Header {
 }
 
 func getOrigin(r *http.Request) string {
-	origin := r.Header.Get("X-Forwarded-For")
-	if origin == "" {
-		origin = r.RemoteAddr
+	forwardedFor := r.Header.Get("X-Forwarded-For")
+	if forwardedFor == "" {
+		return r.RemoteAddr
 	}
-	return origin
+	// take the first entry in a comma-separated list of IP addrs
+	return strings.TrimSpace(strings.SplitN(forwardedFor, ",", 2)[0])
 }
 
 func getURL(r *http.Request) *url.URL {


### PR DESCRIPTION
Instead of returning the contents of `X-Forwarded-For` verbatim as a (likely) comma-separated string of IP addresses, extract just the client IP.

