### PR TITLE
Build docker images for amd64 and arm64 {WIP}

### DIFF
--- a/.github/workflows/continuous_delivery.yaml
+++ b/.github/workflows/continuous_delivery.yaml
@@ -18,13 +18,16 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-    - name: Setup
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Setup go
       uses: actions/setup-go@v2
       with:
         go-version: '1.16'
 
-    - name: Checkout
-      uses: actions/checkout@v2
+    - name: Set up docker buildx
+      uses: docker/setup-buildx-action@v1
 
     - name: Build
       run: make build

--- a/Makefile
+++ b/Makefile
@@ -142,10 +142,10 @@ gcloud-auth:
 # docker images
 # =============================================================================
 image:
-	DOCKER_BUILDKIT=1 docker build -t $(DOCKER_TAG_DOCKERHUB) .
+	docker buildx build --platform linux/amd64,linux/arm64 -t $(DOCKER_TAG_DOCKERHUB) .
 
-imagepush: image
-	docker push $(DOCKER_TAG_DOCKERHUB)
+imagepush:
+	docker buildx build --push --platform linux/amd64,linux/arm64 -t $(DOCKER_TAG_DOCKERHUB) .
 
 
 # =============================================================================


### PR DESCRIPTION
## Problem

current httpbin images don't support arm64 architecture.  that means we can't run them on AWS Graviton's or Apple M1's natively.

## Solution

use buildx to build a multi-arch with `linux/amd64,linux/arm64` platform support.

the biggest change is we have to go from separate build and push steps into a single build and push step.  this is because the local docker doesn't support building locally multi-arch images.

## Notes

based on https://www.docker.com/blog/multi-arch-images/ and https://www.docker.com/blog/multi-arch-build-what-about-circleci/
our upstreams, both `golang:latest` and  alpine:3.10`` support these architectures and more.

addresses: https://github.com/mccutchen/go-httpbin/issues/63