### PR TITLE
Close XSS issue in /base64 endpoint (fixes #67)

### DIFF
--- a/httpbin/handlers.go
+++ b/httpbin/handlers.go
@@ -982,7 +982,7 @@ func (h *HTTPBin) Base64(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, fmt.Sprintf("%s failed: %s", b.operation, base64Error), http.StatusBadRequest)
 		return
 	}
-	writeResponse(w, http.StatusOK, "text/html", result)
+	writeResponse(w, http.StatusOK, "text/plain", result)
 }
 
 // JSON - returns a sample json

--- a/httpbin/handlers_test.go
+++ b/httpbin/handlers_test.go
@@ -2425,6 +2425,7 @@ func TestBase64(t *testing.T) {
 			w := httptest.NewRecorder()
 			handler.ServeHTTP(w, r)
 			assertStatusCode(t, w, http.StatusOK)
+			assertContentType(t, w, "text/plain")
 			assertBodyEquals(t, w, test.want)
 		})
 	}


### PR DESCRIPTION
See https://github.com/mccutchen/go-httpbin/issues/67 for details.  Demonstration of the issue, using the example URL provided (https://httpbingo.org/base64/ZXhhbXBsZS5vcmciPjxzdmcvb25sb2FkPXByb21wdCgneHNzJyk+):

<img width="1044" alt="image" src="https://user-images.githubusercontent.com/57938/143951180-bc18d8bb-1954-456d-b35a-39128aeb017b.png">

With the fix locally:

<img width="990" alt="image" src="https://user-images.githubusercontent.com/57938/143951286-422c858f-2219-4192-9bf8-0ab49349d5bb.png">

Thanks for the report @danbf!


