### PR TITLE
Fix lingering references to the old master branch

### DIFF
--- a/.github/workflows/continuous_delivery.yaml
+++ b/.github/workflows/continuous_delivery.yaml
@@ -2,16 +2,16 @@
 # autonomous deploys to production on merge.
 name: CD
 
-# Translated: "Execute this workflow on pushes to master OR on pull requests
-# opened against master"
+# Translated: "Execute this workflow on pushes to main OR on pull requests
+# opened against main"
 #
 # See this question and answer for what we're solving here:
 # https://github.community/t5/GitHub-Actions/How-to-trigger-an-action-on-push-or-pull-request-but-not-both/m-p/36155#M2460
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
 
 jobs:
   test:
@@ -67,7 +67,7 @@ jobs:
 
   production_deploy:
     name: Production Deploy
-    if: github.ref == 'refs/heads/master'
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     needs: [test]
     steps:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -2,9 +2,9 @@ name: Lint
 
 on:
   push:
-    branches: [master] # pushes TO master
+    branches: [main] # pushes TO main
   pull_request:
-    branches: [master] # pull requests AGAINST master
+    branches: [main] # pull requests AGAINST main
 
 jobs:
   golangci:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A reasonably complete and well-tested golang port of [Kenneth Reitz][kr]'s
 [httpbin][httpbin-org] service, with zero dependencies outside the go stdlib.
 
 [![GoDoc](https://pkg.go.dev/badge/github.com/mccutchen/go-httpbin/v2)](https://pkg.go.dev/github.com/mccutchen/go-httpbin/v2)
-[![Build Status](https://travis-ci.org/mccutchen/go-httpbin.svg?branch=main)](http://travis-ci.org/mccutchen/go-httpbin)
+[![Build status](https://github.com/mccutchen/go-httpbin/actions/workflows/continuous_delivery.yaml/badge.svg)](https://github.com/mccutchen/go-httpbin/actions/workflows/continuous_delivery.yaml)
 [![Coverage](https://codecov.io/gh/mccutchen/go-httpbin/branch/main/graph/badge.svg)](https://codecov.io/gh/mccutchen/go-httpbin)
 
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ A reasonably complete and well-tested golang port of [Kenneth Reitz][kr]'s
 [httpbin][httpbin-org] service, with zero dependencies outside the go stdlib.
 
 [![GoDoc](https://pkg.go.dev/badge/github.com/mccutchen/go-httpbin/v2)](https://pkg.go.dev/github.com/mccutchen/go-httpbin/v2)
-[![Build Status](https://travis-ci.org/mccutchen/go-httpbin.svg?branch=master)](http://travis-ci.org/mccutchen/go-httpbin)
-[![Coverage](https://codecov.io/gh/mccutchen/go-httpbin/branch/master/graph/badge.svg)](https://codecov.io/gh/mccutchen/go-httpbin)
+[![Build Status](https://travis-ci.org/mccutchen/go-httpbin.svg?branch=main)](http://travis-ci.org/mccutchen/go-httpbin)
+[![Coverage](https://codecov.io/gh/mccutchen/go-httpbin/branch/main/graph/badge.svg)](https://codecov.io/gh/mccutchen/go-httpbin)
 
 
 ## Usage


### PR DESCRIPTION
Was wondering why the github actions weren't running on #68, this should do it.