### PR TITLE
Add /hostname endpoint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ TOOL_BIN_DIR     ?= $(shell go env GOPATH)/bin
 TOOL_GOLINT      := $(TOOL_BIN_DIR)/golint
 TOOL_STATICCHECK := $(TOOL_BIN_DIR)/staticcheck
 
-GO_SOURCES = $(wildcard **/*.go)
+GO_SOURCES = $(shell find . -name *.go)
 
 
 # =============================================================================

--- a/README.md
+++ b/README.md
@@ -6,29 +6,34 @@ A reasonably complete and well-tested golang port of [Kenneth Reitz][kr]'s
 [![GoDoc](https://pkg.go.dev/badge/github.com/mccutchen/go-httpbin/v2)](https://pkg.go.dev/github.com/mccutchen/go-httpbin/v2)
 [![Build status](https://github.com/mccutchen/go-httpbin/actions/workflows/test.yaml/badge.svg)](https://github.com/mccutchen/go-httpbin/actions/workflows/test.yaml)
 [![Coverage](https://codecov.io/gh/mccutchen/go-httpbin/branch/main/graph/badge.svg)](https://codecov.io/gh/mccutchen/go-httpbin)
+[![Docker Pulls](https://badgen.net/docker/pulls/mccutchen/go-httpbin?icon=docker&label=pulls)](https://hub.docker.com/r/mccutchen/go-httpbin/)
 
 
 ## Usage
 
-Run as a standalone binary, configured by command line flags or environment
-variables:
 
-```
-$ go-httpbin --help
-Usage of go-httpbin:
-  -host string
-      Host to listen on (default "0.0.0.0")
-  -https-cert-file string
-      HTTPS Server certificate file
-  -https-key-file string
-      HTTPS Server private key file
-  -max-body-size int
-      Maximum size of request or response, in bytes (default 1048576)
-  -max-duration duration
-      Maximum duration a response may take (default 10s)
-  -port int
-      Port to listen on (default 8080)
-```
+### Configuration
+
+go-httpbin can be configured via either command line arguments or environment
+variables (or a combination of the two):
+
+| Argument| Env var | Documentation | Default |
+| - | - | - | - |
+| `-host` | `HOST` | Host to listen on | "0.0.0.0" |
+| `-https-cert-file` | `HTTPS_CERT_FILE` | HTTPS Server certificate file | |
+| `-https-key-file` | `HTTPS_KEY_FILE` | HTTPS Server private key file | |
+| `-max-body-size` | `MAX_BODY_SIZE` | Maximum size of request or response, in bytes | 1048576 |
+| `-max-duration` | `MAX_DURATION` | Maximum duration a response may take | 10s |
+| `-port` | `PORT` | Port to listen on | 8080 |
+| `-use-real-hostname` | `USE_REAL_HOSTNAME` | Expose real hostname as reported by os.Hostname() in the /hostname endpoint | false |
+
+**Note:** Command line arguments take precedence over environment variables.
+
+
+### Standalone binary
+
+Follow the [Installation](#installation) instructions to install go-httpbin as
+a standalone binary. (This currently requires a working Go runtime.)
 
 Examples:
 
@@ -43,6 +48,8 @@ $ openssl req -new -x509 -sha256 -key server.key -out server.crt -days 3650
 $ go-httpbin -host 127.0.0.1 -port 8081 -https-cert-file ./server.crt -https-key-file ./server.key
 ```
 
+### Docker
+
 Docker images are published to [Docker Hub][docker-hub]:
 
 ```bash
@@ -52,6 +59,8 @@ $ docker run -P mccutchen/go-httpbin
 # Run https server
 $ docker run -e HTTPS_CERT_FILE='/tmp/server.crt' -e HTTPS_KEY_FILE='/tmp/server.key' -p 8080:8080 -v /tmp:/tmp mccutchen/go-httpbin
 ```
+
+### Unit testing helper library
 
 The `github.com/mccutchen/go-httpbin/httpbin/v2` package can also be used as a
 library for testing an application's interactions with an upstream HTTP

--- a/httpbin/handlers.go
+++ b/httpbin/handlers.go
@@ -1004,3 +1004,11 @@ func (h *HTTPBin) Bearer(w http.ResponseWriter, r *http.Request) {
 	})
 	writeJSON(w, body, http.StatusOK)
 }
+
+// Hostname - returns the hostname.
+func (h *HTTPBin) Hostname(w http.ResponseWriter, r *http.Request) {
+	body, _ := json.Marshal(hostnameResponse{
+		Hostname: h.hostname,
+	})
+	writeJSON(w, body, http.StatusOK)
+}

--- a/httpbin/httpbin.go
+++ b/httpbin/httpbin.go
@@ -10,6 +10,7 @@ import (
 const (
 	DefaultMaxBodySize int64 = 1024 * 1024
 	DefaultMaxDuration       = 10 * time.Second
+	DefaultHostname          = "go-httpbin"
 )
 
 const (
@@ -87,6 +88,10 @@ type bearerResponse struct {
 	Token         string `json:"token"`
 }
 
+type hostnameResponse struct {
+	Hostname string `json:"hostname"`
+}
+
 // HTTPBin contains the business logic
 type HTTPBin struct {
 	// Max size of an incoming request generated response body, in bytes
@@ -101,6 +106,9 @@ type HTTPBin struct {
 
 	// Default parameter values
 	DefaultParams DefaultParams
+
+	// The hostname to expose via /hostname.
+	hostname string
 }
 
 // DefaultParams defines default parameter values
@@ -137,6 +145,7 @@ func (h *HTTPBin) Handler() http.Handler {
 	mux.HandleFunc("/user-agent", h.UserAgent)
 	mux.HandleFunc("/headers", h.Headers)
 	mux.HandleFunc("/response-headers", h.ResponseHeaders)
+	mux.HandleFunc("/hostname", h.Hostname)
 
 	mux.HandleFunc("/status/", h.Status)
 	mux.HandleFunc("/unstable", h.Unstable)
@@ -222,6 +231,7 @@ func New(opts ...OptionFunc) *HTTPBin {
 		MaxBodySize:   DefaultMaxBodySize,
 		MaxDuration:   DefaultMaxDuration,
 		DefaultParams: DefaultDefaultParams,
+		hostname:      DefaultHostname,
 	}
 	for _, opt := range opts {
 		opt(h)
@@ -251,6 +261,13 @@ func WithMaxBodySize(m int64) OptionFunc {
 func WithMaxDuration(d time.Duration) OptionFunc {
 	return func(h *HTTPBin) {
 		h.MaxDuration = d
+	}
+}
+
+// WithHostname sets the hostname to return via the /hostname endpoint.
+func WithHostname(s string) OptionFunc {
+	return func(h *HTTPBin) {
+		h.hostname = s
 	}
 }
 

--- a/httpbin/static/index.html
+++ b/httpbin/static/index.html
@@ -88,6 +88,7 @@
 <li><a href="/headers"><code>/headers</code></a> Returns request header dict.</li>
 <li><a href="/hidden-basic-auth/user/passwd"><code>/hidden-basic-auth/:user/:passwd</code></a> 404'd BasicAuth.</li>
 <li><a href="/html"><code>/html</code></a> Renders an HTML Page.</li>
+<li><a href="/hostname"><code>/hostname</code></a> Returns the name of the host serving the request.</li>
 <li><a href="/image"><code>/image</code></a> Returns page containing an image based on sent Accept header.</li>
 <li><a href="/image/jpeg"><code>/image/jpeg</code></a> Returns a JPEG image.</li>
 <li><a href="/image/png"><code>/image/png</code></a> Returns a PNG image.</li>


### PR DESCRIPTION
This adds a new /hostname endpoint as originally proposed in https://github.com/mccutchen/go-httpbin/pull/66.

In this implementation, it exposes a dummy hostname by default, and only exposes the real hostname (via `os.Hostname()`) if the `-use-real-hostname` flag or `USE_REAL_HOSTNAME` env vars are set to true, which should make this safe for users to adopt without unintentionally exposing details of the underlying infrastructure unless they want to.

cc @uromahn @x70b1