### PR TITLE
Update golang to 1.19

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.18'
+          go-version: '1.19'
       - uses: golangci/golangci-lint-action@v3.1.0
         with:
           version: v1.45.2

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,7 +19,7 @@ jobs:
     steps:
     - uses: actions/setup-go@v2
       with:
-        go-version: '1.18'
+        go-version: '1.19'
 
     - uses: actions/checkout@v2
 
@@ -38,8 +38,8 @@ jobs:
     strategy:
       matrix:
         go_version:
+        - '1.18'
         - '1.17'
-        - '1.16'
 
     steps:
     - uses: actions/setup-go@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,18 @@
 # syntax = docker/dockerfile:1.3
-FROM golang:1.18
+# Golang
+FROM golang:1.19 as build
 
 WORKDIR /go/src/github.com/mccutchen/go-httpbin
 
 COPY . .
+
 RUN --mount=type=cache,id=gobuild,target=/root/.cache/go-build \
     make build buildtests
 
+# distroless
 FROM gcr.io/distroless/base
-COPY --from=0 /go/src/github.com/mccutchen/go-httpbin/dist/go-httpbin* /bin/
+
+COPY --from=build /go/src/github.com/mccutchen/go-httpbin/dist/go-httpbin* /bin/
+
 EXPOSE 8080
-CMD ["/bin/go-httpbin"]
+ENTRYPOINT ["/bin/go-httpbin"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 # syntax = docker/dockerfile:1.3
-# Golang
-FROM golang:1.19 as build
+FROM golang:1.19 AS build
 
 WORKDIR /go/src/github.com/mccutchen/go-httpbin
 
@@ -9,10 +8,10 @@ COPY . .
 RUN --mount=type=cache,id=gobuild,target=/root/.cache/go-build \
     make build buildtests
 
-# distroless
 FROM gcr.io/distroless/base
 
 COPY --from=build /go/src/github.com/mccutchen/go-httpbin/dist/go-httpbin* /bin/
 
 EXPOSE 8080
+
 ENTRYPOINT ["/bin/go-httpbin"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,5 +13,4 @@ FROM gcr.io/distroless/base
 COPY --from=build /go/src/github.com/mccutchen/go-httpbin/dist/go-httpbin* /bin/
 
 EXPOSE 8080
-
-ENTRYPOINT ["/bin/go-httpbin"]
+CMD ["/bin/go-httpbin"]


### PR DESCRIPTION
I updated golang to 1.19.

Other than that I replaced `CMD` with `ENTRYPOINT`. This container image is a very good example for the difference between booth settings. You can now use the `CMD` for command line options. Example:

```
 nerdctl run mccutchen/go-httpbin -use-real-hostname
```
