### PR TITLE
Add workflow to push docker images for new releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,54 @@
+# This action pushes new amd64 and arm64 docker images to the Docker and GitHub
+# registries on every new release of the project.
+#
+# Cobbled together from these sources:
+# - https://github.com/docker/build-push-action/#usage
+# - https://docs.github.com/en/actions/publishing-packages/publishing-docker-images
+
+name: Release
+
+"on":
+  release:
+    types: [published]
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: mccutchen
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            mccutchen/go-httpbin
+            ghrc.io/mccutchen/go-httpbin
+
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Let's automate this chore.

Unfortunately, I don't know of a good way to test this, so I guess I'll wait for the next release and see what breaks.  I'm suspicious, in particular, of my ability to push directly to ghcr.io with the default permissions given to GH Actions on this repo, but we'll see!