### PR TITLE
More comprehensive tests for HTTP verb endpoints

### DIFF
--- a/httpbin/digest/digest.go
+++ b/httpbin/digest/digest.go
@@ -92,15 +92,15 @@ type authorization struct {
 // parseAuthorizationHeader parses an Authorization header into an
 // Authorization struct, given a an authorization header like:
 //
-//    Authorization: Digest username="Mufasa",
-//                         realm="testrealm@host.com",
-//                         nonce="dcd98b7102dd2f0e8b11d0f600bfb0c093",
-//                         uri="/dir/index.html",
-//                         qop=auth,
-//                         nc=00000001,
-//                         cnonce="0a4f113b",
-//                         response="6629fae49393a05397450978507c4ef1",
-//                         opaque="5ccc069c403ebaf9f0171e9517f40e41"
+//	Authorization: Digest username="Mufasa",
+//	                     realm="testrealm@host.com",
+//	                     nonce="dcd98b7102dd2f0e8b11d0f600bfb0c093",
+//	                     uri="/dir/index.html",
+//	                     qop=auth,
+//	                     nc=00000001,
+//	                     cnonce="0a4f113b",
+//	                     response="6629fae49393a05397450978507c4ef1",
+//	                     opaque="5ccc069c403ebaf9f0171e9517f40e41"
 //
 // If the given value does not contain a Digest authorization header, or is in
 // some other way malformed, nil is returned.
@@ -174,7 +174,7 @@ func hash(data []byte, algorithm digestAlgorithm) string {
 
 // makeHA1 returns the HA1 hash, where
 //
-//     HA1 = H(A1) = H(username:realm:password)
+//	HA1 = H(A1) = H(username:realm:password)
 //
 // and H is one of MD5 or SHA256.
 func makeHA1(realm, username, password string, algorithm digestAlgorithm) string {
@@ -184,7 +184,7 @@ func makeHA1(realm, username, password string, algorithm digestAlgorithm) string
 
 // makeHA2 returns the HA2 hash, where
 //
-//     HA2 = H(A2) = H(method:digestURI)
+//	HA2 = H(A2) = H(method:digestURI)
 //
 // and H is one of MD5 or SHA256.
 func makeHA2(auth *authorization, method, uri string) string {
@@ -195,11 +195,11 @@ func makeHA2(auth *authorization, method, uri string) string {
 // Response calculates the correct digest auth response. If the qop directive's
 // value is "auth" or "auth-int" , then compute the response as
 //
-//    RESPONSE = H(HA1:nonce:nonceCount:clientNonce:qop:HA2)
+//	RESPONSE = H(HA1:nonce:nonceCount:clientNonce:qop:HA2)
 //
 // and if the qop directive is unspecified, then compute the response as
 //
-//    RESPONSE = H(HA1:nonce:HA2)
+//	RESPONSE = H(HA1:nonce:HA2)
 //
 // where H is one of MD5 or SHA256.
 func response(auth *authorization, password, method, uri string) string {

--- a/httpbin/handlers.go
+++ b/httpbin/handlers.go
@@ -48,7 +48,7 @@ func (h *HTTPBin) UTF8(w http.ResponseWriter, r *http.Request) {
 
 // Get handles HTTP GET requests
 func (h *HTTPBin) Get(w http.ResponseWriter, r *http.Request) {
-	resp := &getResponse{
+	resp := &noBodyResponse{
 		Args:    r.URL.Query(),
 		Headers: getRequestHeaders(r),
 		Origin:  getClientIP(r),
@@ -56,6 +56,16 @@ func (h *HTTPBin) Get(w http.ResponseWriter, r *http.Request) {
 	}
 	body, _ := json.Marshal(resp)
 	writeJSON(w, body, http.StatusOK)
+}
+
+// Anything returns anything that is passed to request.
+func (h *HTTPBin) Anything(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case "GET", "HEAD":
+		h.Get(w, r)
+	default:
+		h.RequestWithBody(w, r)
+	}
 }
 
 // RequestWithBody handles POST, PUT, and PATCH requests
@@ -712,7 +722,7 @@ func (h *HTTPBin) ETag(w http.ResponseWriter, r *http.Request) {
 
 	// TODO: This mostly duplicates the work of Get() above, should this be
 	// pulled into a little helper?
-	resp := &getResponse{
+	resp := &noBodyResponse{
 		Args:    r.URL.Query(),
 		Headers: getRequestHeaders(r),
 		Origin:  getClientIP(r),

--- a/httpbin/helpers.go
+++ b/httpbin/helpers.go
@@ -123,6 +123,13 @@ func parseBody(w http.ResponseWriter, r *http.Request, resp *bodyResponse) error
 	ct := r.Header.Get("Content-Type")
 	switch {
 	case strings.HasPrefix(ct, "application/x-www-form-urlencoded"):
+		// r.ParseForm() does not populate r.PostForm for DELETE requests, but
+		// we need it to for compatibility with the httpbin implementation, so
+		// we trick it with this ugly hack.
+		if r.Method == http.MethodDelete {
+			r.Method = http.MethodPost
+			defer func() { r.Method = http.MethodDelete }()
+		}
 		if err := r.ParseForm(); err != nil {
 			return err
 		}

--- a/httpbin/httpbin.go
+++ b/httpbin/httpbin.go
@@ -30,14 +30,17 @@ type userAgentResponse struct {
 	UserAgent string `json:"user-agent"`
 }
 
-type getResponse struct {
+// A generic response for any incoming request that should not contain a body
+// (GET, HEAD, OPTIONS, etc).
+type noBodyResponse struct {
 	Args    url.Values  `json:"args"`
 	Headers http.Header `json:"headers"`
 	Origin  string      `json:"origin"`
 	URL     string      `json:"url"`
 }
 
-// A generic response for any incoming request that might contain a body
+// A generic response for any incoming request that might contain a body (POST,
+// PUT, PATCH, etc).
 type bodyResponse struct {
 	Args    url.Values  `json:"args"`
 	Headers http.Header `json:"headers"`
@@ -141,6 +144,9 @@ func (h *HTTPBin) Handler() http.Handler {
 	mux.HandleFunc("/post", methods(h.RequestWithBody, "POST"))
 	mux.HandleFunc("/put", methods(h.RequestWithBody, "PUT"))
 
+	mux.HandleFunc("/anything", h.Anything)
+	mux.HandleFunc("/anything/", h.Anything)
+
 	mux.HandleFunc("/ip", h.IP)
 	mux.HandleFunc("/user-agent", h.UserAgent)
 	mux.HandleFunc("/headers", h.Headers)
@@ -154,9 +160,6 @@ func (h *HTTPBin) Handler() http.Handler {
 	mux.HandleFunc("/relative-redirect/", h.RelativeRedirect)
 	mux.HandleFunc("/absolute-redirect/", h.AbsoluteRedirect)
 	mux.HandleFunc("/redirect-to", h.RedirectTo)
-
-	mux.HandleFunc("/anything/", h.RequestWithBody)
-	mux.HandleFunc("/anything", h.RequestWithBody)
 
 	mux.HandleFunc("/cookies", h.Cookies)
 	mux.HandleFunc("/cookies/set", h.SetCookies)


### PR DESCRIPTION
We were not explicitly testing the behavior of some HTTP verb endpoints like `/put`, `/patch`, and `/delete`, because they (currently) share an underlying handler with `/post` which is thoroughly tested.

The addition of the `/anything` endpoint in #83 made me realize a bit more explicit test coverage would be good, so here we're landing a bit of a refactoring of the test suite to generate tests for all of those endpoints.

Along the way, the more thorough test coverage uncovered a compatibility issue with the original httpbin implementation, which supports `DELETE` requests with bodies.  We handle that by tricking the stdlib net/http machinery into parsing those request bodies.