### PR TITLE
Disable pushes to ghcr.io on release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,20 +30,12 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: mccutchen
-          password: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Extract metadata for Docker
         id: meta
         uses: docker/metadata-action@v4
         with:
           images: |
             mccutchen/go-httpbin
-            ghrc.io/mccutchen/go-httpbin
 
       - name: Build and push
         uses: docker/build-push-action@v3


### PR DESCRIPTION
I now know from wrestling with this in another repo (https://github.com/mccutchen/kafka-lite/pull/6, https://github.com/mccutchen/kafka-lite/pull/8, https://github.com/mccutchen/kafka-lite/pull/9, https://github.com/mccutchen/kafka-lite/pull/10) that the release automation added in #87 is going to break on pushes to ghcr.io.