### PR TITLE
Allow restricting redirect destinations

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,24 +11,17 @@ A reasonably complete and well-tested golang port of [Kenneth Reitz][kr]'s
 
 ## Usage
 
+### Docker
 
-### Configuration
+Docker images are published to [Docker Hub][docker-hub]:
 
-go-httpbin can be configured via either command line arguments or environment
-variables (or a combination of the two):
+```bash
+# Run http server
+$ docker run -P mccutchen/go-httpbin
 
-| Argument| Env var | Documentation | Default |
-| - | - | - | - |
-| `-host` | `HOST` | Host to listen on | "0.0.0.0" |
-| `-https-cert-file` | `HTTPS_CERT_FILE` | HTTPS Server certificate file | |
-| `-https-key-file` | `HTTPS_KEY_FILE` | HTTPS Server private key file | |
-| `-max-body-size` | `MAX_BODY_SIZE` | Maximum size of request or response, in bytes | 1048576 |
-| `-max-duration` | `MAX_DURATION` | Maximum duration a response may take | 10s |
-| `-port` | `PORT` | Port to listen on | 8080 |
-| `-use-real-hostname` | `USE_REAL_HOSTNAME` | Expose real hostname as reported by os.Hostname() in the /hostname endpoint | false |
-
-**Note:** Command line arguments take precedence over environment variables.
-
+# Run https server
+$ docker run -e HTTPS_CERT_FILE='/tmp/server.crt' -e HTTPS_KEY_FILE='/tmp/server.key' -p 8080:8080 -v /tmp:/tmp mccutchen/go-httpbin
+```
 
 ### Standalone binary
 
@@ -46,18 +39,6 @@ $ openssl genrsa -out server.key 2048
 $ openssl ecparam -genkey -name secp384r1 -out server.key
 $ openssl req -new -x509 -sha256 -key server.key -out server.crt -days 3650
 $ go-httpbin -host 127.0.0.1 -port 8081 -https-cert-file ./server.crt -https-key-file ./server.key
-```
-
-### Docker
-
-Docker images are published to [Docker Hub][docker-hub]:
-
-```bash
-# Run http server
-$ docker run -P mccutchen/go-httpbin
-
-# Run https server
-$ docker run -e HTTPS_CERT_FILE='/tmp/server.crt' -e HTTPS_KEY_FILE='/tmp/server.key' -p 8080:8080 -v /tmp:/tmp mccutchen/go-httpbin
 ```
 
 ### Unit testing helper library
@@ -95,16 +76,26 @@ func TestSlowResponse(t *testing.T) {
 }
 ```
 
+### Configuration
 
-## Custom instrumentation
+go-httpbin can be configured via either command line arguments or environment
+variables (or a combination of the two):
 
-If you're running go-httpbin in your own infrastructure and would like custom
-instrumentation (metrics, structured logging, request tracing, etc), you'll
-need to wrap this package in your own code and use the included
-[Observer][observer] mechanism to instrument requests as necessary.
+| Argument| Env var | Documentation | Default |
+| - | - | - | - |
+| `-allowed-redirect-domains` | `ALLOWED_REDIRECT_DOMAINS` | Comma-separated list of domains the /redirect-to endpoint will allow | |
+| `-host` | `HOST` | Host to listen on | "0.0.0.0" |
+| `-https-cert-file` | `HTTPS_CERT_FILE` | HTTPS Server certificate file | |
+| `-https-key-file` | `HTTPS_KEY_FILE` | HTTPS Server private key file | |
+| `-max-body-size` | `MAX_BODY_SIZE` | Maximum size of request or response, in bytes | 1048576 |
+| `-max-duration` | `MAX_DURATION` | Maximum duration a response may take | 10s |
+| `-port` | `PORT` | Port to listen on | 8080 |
+| `-use-real-hostname` | `USE_REAL_HOSTNAME` | Expose real hostname as reported by os.Hostname() in the /hostname endpoint | false |
 
-See [examples/custom-instrumentation][custom-instrumentation] for an example
-that instruments every request using DataDog.
+**Notes:**
+- Command line arguments take precedence over environment variables.
+- See [Production considerations] for recommendations around safe configuration
+  of public instances of go-httpbin
 
 
 ## Installation
@@ -121,6 +112,66 @@ To install the `go-httpbin` binary:
 go install github.com/mccutchen/go-httpbin/v2/cmd/go-httpbin
 ```
 
+
+## Production considerations
+
+Before deploying an instance of go-httpbin on your own infrastructure on the
+public internet, consider tuning it appropriately:
+
+1. **Restrict the domains to which the `/redirect-to` endpoint will send
+   traffic to avoid the security issues of an open redirect**
+
+   Use the `-allowed-redirect-domains` CLI argument or the
+   `ALLOWED_REDIRECT_DOMAINS` env var to configure an appropriate allowlist.
+
+2. **Tune per-request limits**
+
+   Because go-httpbin allows clients send arbitrary data in request bodies and
+   control the duration some requests (e.g. `/delay/60s`), it's important to
+   properly tune limits to prevent misbehaving or malicious clients from taking
+   too many resources.
+
+   Use the `-max-body-size`/`MAX_BODY_SIZE` and `-max-duration`/`MAX_DURATION`
+   CLI arguments or env vars to enforce appropriate limits on each request.
+
+3. **Decide whether to expose real hostnames in the `/hostname` endpoint**
+
+   By default, the `/hostname` endpoint serves a dummy hostname value, but it
+   can be configured to serve the real underlying hostname (according to
+   `os.Hostname()`) using the `-use-real-hostname` CLI argument or the
+   `USE_REAL_HOSTNAME` env var to enable this functionality.
+
+   Before enabling this, ensure that your hostnames do not reveal too much
+   about your underlying infrastructure.
+
+4. **Add custom instrumentation**
+
+   By default, go-httpbin logs basic information about each request. To add
+   more detailed instrumentation (metrics, structured logging, request
+   tracing), you'll need to wrap this package in your own code, which you can
+   then instrument as you would any net/http server. Some examples:
+
+   - [examples/custom-instrumentation] instruments every request using DataDog,
+     based on the built-in [Observer] mechanism.
+
+   - [mccutchen/httpbingo.org] is the code that powers the public instance of
+     go-httpbin deployed to [httpbingo.org], which adds customized structured
+     logging using [zerolog] and further hardens the HTTP server against
+     malicious clients by tuning lower-level timeouts and limits.
+
+## Development
+
+```bash
+# local development
+make
+make test
+make testcover
+make run
+
+# building & pushing docker images
+make image
+make imagepush
+```
 
 ## Motivation & prior art
 
@@ -148,24 +199,14 @@ Compared to [ahmetb/go-httpbin][ahmet]:
  - More complete implementation of endpoints
 
 
-## Development
-
-```bash
-# local development
-make
-make test
-make testcover
-make run
-
-# building & pushing docker images
-make image
-make imagepush
-```
-
-[kr]: https://github.com/kennethreitz
-[httpbin-org]: https://httpbin.org/
-[httpbin-repo]: https://github.com/kennethreitz/httpbin
 [ahmet]: https://github.com/ahmetb/go-httpbin
 [docker-hub]: https://hub.docker.com/r/mccutchen/go-httpbin/
-[observer]: https://pkg.go.dev/github.com/mccutchen/go-httpbin/v2/httpbin#Observer
-[custom-instrumentation]: ./examples/custom-instrumentation/
+[examples/custom-instrumentation]: ./examples/custom-instrumentation/
+[httpbin-org]: https://httpbin.org/
+[httpbin-repo]: https://github.com/kennethreitz/httpbin
+[httpbingo.org]: https://httpbingo.org/
+[kr]: https://github.com/kennethreitz
+[mccutchen/httpbingo.org]: https://github.com/mccutchen/httpbingo.org
+[Observer]: https://pkg.go.dev/github.com/mccutchen/go-httpbin/v2/httpbin#Observer
+[Production considerations]: #production-considerations
+[zerolog]: https://github.com/rs/zerolog

--- a/httpbin/httpbin.go
+++ b/httpbin/httpbin.go
@@ -101,6 +101,9 @@ type HTTPBin struct {
 	// Default parameter values
 	DefaultParams DefaultParams
 
+	// Set of hosts to which the /redirect-to endpoint will allow redirects
+	AllowedRedirectDomains map[string]struct{}
+
 	// The hostname to expose via /hostname.
 	hostname string
 }
@@ -272,5 +275,17 @@ func WithHostname(s string) OptionFunc {
 func WithObserver(o Observer) OptionFunc {
 	return func(h *HTTPBin) {
 		h.Observer = o
+	}
+}
+
+// WithAllowedRedirectDomains limits the domains to which the /redirect-to
+// endpoint will redirect traffic.
+func WithAllowedRedirectDomains(hosts []string) OptionFunc {
+	return func(h *HTTPBin) {
+		hostSet := make(map[string]struct{}, len(hosts))
+		for _, host := range hosts {
+			hostSet[host] = struct{}{}
+		}
+		h.AllowedRedirectDomains = hostSet
 	}
 }


### PR DESCRIPTION
The `/redirect-to` endpoint currently acts as an open redirect, which is bad for any go-httpbin instance exposed to the public internet.

This allows configuring an allowlist of domains to which traffic can be redirected, which should address https://github.com/mccutchen/go-httpbin/security/code-scanning/4.

While we're at it, add some specific production configuration guidance to the README.