### PR TITLE
cmd: fix help output

### DIFF
--- a/httpbin/cmd/cmd.go
+++ b/httpbin/cmd/cmd.go
@@ -131,7 +131,7 @@ func (e ConfigError) Error() string {
 func loadConfig(args []string, getEnv func(string) string, getHostname func() (string, error)) (*config, error) {
 	cfg := &config{}
 
-	fs := flag.NewFlagSet("", flag.ContinueOnError)
+	fs := flag.NewFlagSet("go-httpbin", flag.ContinueOnError)
 	fs.BoolVar(&cfg.rawUseRealHostname, "use-real-hostname", false, "Expose value of os.Hostname() in the /hostname endpoint instead of dummy value")
 	fs.DurationVar(&cfg.MaxDuration, "max-duration", httpbin.DefaultMaxDuration, "Maximum duration a response may take")
 	fs.Int64Var(&cfg.MaxBodySize, "max-body-size", httpbin.DefaultMaxBodySize, "Maximum size of request or response, in bytes")

--- a/httpbin/cmd/cmd_test.go
+++ b/httpbin/cmd/cmd_test.go
@@ -14,7 +14,7 @@ import (
 
 // To update, run:
 // make && ./dist/go-httpbin -h 2>&1 | pbcopy
-const usage = `Usage:
+const usage = `Usage of go-httpbin:
   -allowed-redirect-domains string
     	Comma-separated list of domains the /redirect-to endpoint will allow
   -host string


### PR DESCRIPTION
Fix a small regression in #98, best illustrated by this diff:

```diff
--- help.before	2022-11-13 11:43:51.000000000 -0500
+++ help.after	2022-11-13 11:43:56.000000000 -0500
@@ -1,4 +1,4 @@
-Usage:
+Usage of go-httpbin:
   -allowed-redirect-domains string
     	Comma-separated list of domains the /redirect-to endpoint will allow
   -host string
```