### PR TITLE
feat: ensure that 404 responses indicate that they originate from go-httpbin

### DIFF
--- a/httpbin/handlers.go
+++ b/httpbin/handlers.go
@@ -23,7 +23,8 @@ func notImplementedHandler(w http.ResponseWriter, r *http.Request) {
 // Index renders an HTML index page
 func (h *HTTPBin) Index(w http.ResponseWriter, r *http.Request) {
 	if r.URL.Path != "/" {
-		http.Error(w, "Not Found", http.StatusNotFound)
+		msg := fmt.Sprintf("Not Found (go-httpbin does not have the API: %s)", r.URL.Path)
+		http.Error(w, msg, http.StatusNotFound)
 		return
 	}
 	w.Header().Set("Content-Security-Policy", "default-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' camo.githubusercontent.com")

--- a/httpbin/handlers.go
+++ b/httpbin/handlers.go
@@ -23,7 +23,7 @@ func notImplementedHandler(w http.ResponseWriter, r *http.Request) {
 // Index renders an HTML index page
 func (h *HTTPBin) Index(w http.ResponseWriter, r *http.Request) {
 	if r.URL.Path != "/" {
-		msg := fmt.Sprintf("Not Found (go-httpbin does not have the API: %s)", r.URL.Path)
+		msg := fmt.Sprintf("Not Found (go-httpbin does not handle the path %s)", r.URL.Path)
 		http.Error(w, msg, http.StatusNotFound)
 		return
 	}

--- a/httpbin/handlers_test.go
+++ b/httpbin/handlers_test.go
@@ -116,6 +116,7 @@ func TestIndex__NotFound(t *testing.T) {
 	w := httptest.NewRecorder()
 	app.ServeHTTP(w, r)
 	assertStatusCode(t, w, http.StatusNotFound)
+	assertBodyContains(t, w, "/foo")
 }
 
 func TestFormsPost(t *testing.T) {


### PR DESCRIPTION
When go-httpbin is used as a test service and accessed through a gateway, 404 may be returned due to incorrect configuration of the gateway. 
By optimizing the response content, you can clearly know whether the 404 is returned by the gateway or go-httpbin.