### PR TITLE
feat: Add /dump/request endpoint

### DIFF
--- a/httpbin/handlers.go
+++ b/httpbin/handlers.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/http/httputil"
 	"net/url"
 	"sort"
 	"strconv"
@@ -1011,6 +1012,20 @@ func (h *HTTPBin) Base64(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeResponse(w, http.StatusOK, "text/plain", result)
+}
+
+// DumpRequest - returns the given request in its HTTP/1.x wire representation.
+// The returned representation is an approximation only;
+// some details of the initial request are lost while parsing it into
+// an http.Request. In particular, the order and case of header field
+// names are lost.
+func (h *HTTPBin) DumpRequest(w http.ResponseWriter, r *http.Request) {
+	dump, err := httputil.DumpRequest(r, true)
+	if err != nil {
+		http.Error(w, fmt.Sprint(err), http.StatusInternalServerError)
+		return
+	}
+	fmt.Fprintf(w, "%s", dump)
 }
 
 // JSON - returns a sample json

--- a/httpbin/handlers_test.go
+++ b/httpbin/handlers_test.go
@@ -2840,6 +2840,16 @@ func TestBase64(t *testing.T) {
 	}
 }
 
+func TestDumpRequest(t *testing.T) {
+	t.Parallel()
+	r, _ := http.NewRequest("GET", "/dump/request", nil)
+	w := httptest.NewRecorder()
+	app.ServeHTTP(w, r)
+
+	assertContentType(t, w, "text/plain; charset=utf-8")
+	assertBodyEquals(t, w, "GET /dump/request HTTP/1.1\r\n\r\n")
+}
+
 func TestJSON(t *testing.T) {
 	t.Parallel()
 	r, _ := http.NewRequest("GET", "/json", nil)

--- a/httpbin/httpbin.go
+++ b/httpbin/httpbin.go
@@ -145,6 +145,8 @@ func (h *HTTPBin) Handler() http.Handler {
 	mux.HandleFunc("/uuid", h.UUID)
 	mux.HandleFunc("/base64/", h.Base64)
 
+	mux.HandleFunc("/dump/request", h.DumpRequest)
+
 	// existing httpbin endpoints that we do not support
 	mux.HandleFunc("/brotli", notImplementedHandler)
 

--- a/httpbin/static/index.html
+++ b/httpbin/static/index.html
@@ -80,6 +80,7 @@
 <li><a href="/digest-auth/auth/user/passwd/MD5"><code>/digest-auth/:qop/:user/:passwd/:algorithm</code></a> Challenges HTTP Digest Auth.</li>
 <li><a href="/digest-auth/auth/user/passwd/MD5"><code>/digest-auth/:qop/:user/:passwd</code></a> Challenges HTTP Digest Auth.</li>
 <li><a href="/drip?code=200&amp;numbytes=5&amp;duration=5"><code>/drip?numbytes=n&amp;duration=s&amp;delay=s&amp;code=code</code></a> Drips data over a duration after an optional initial delay, then (optionally) returns with the given status code.</li>
+<li><a href="/dump/request"><code>/dump/request</code></a> Returns the given request in its HTTP/1.x wire approximate representation.</li>
 <li><a href="/encoding/utf8"><code>/encoding/utf8</code></a> Returns page containing UTF-8 data.</li>
 <li><a href="/etag/etag"><code>/etag/:etag</code></a> Assumes the resource has the given etag and responds to If-None-Match header with a 200 or 304 and If-Match with a 200 or 412 as appropriate.</li>
 <li><a href="/forms/post"><code>/forms/post</code></a> HTML form that submits to <em>/post</em></li>
@@ -156,6 +157,14 @@
   "origin": "73.238.9.52, 77.83.142.42",
   "url": "https://httpbingo.org/get?foo=bar"
 }
+</code></pre>
+
+<h3 id="-curl-http-httpbin-org-dump-request">$ curl https://httpbingo.org/dump/request?foo=bar</h3>
+
+<pre><code>GET /dump/request?foo=bar HTTP/1.1
+Host: httpbingo.org
+Accept: */*
+User-Agent: curl/7.64.1
 </code></pre>
 
 <h3 id="-curl-I-http-httpbin-org-status-418">$ curl -I https://httpbingo.org/status/418</h3>


### PR DESCRIPTION
This adds a new /dump/request endpoint.

It's used by servers to debug client requests.
The returned representation is an approximation only;
some details of the initial request are lost while parsing it intoan http.Request. 
In particular, the order and case of header field names are lost.