### PR TITLE
ci: update codecov action

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -12,10 +12,11 @@ coverage:
 
   # https://docs.codecov.io/docs/commit-status
   status:
-    target: auto
-    threshold: 2
-    patch: no
-    changes: no
+    project:
+      default:
+        target: auto
+        base: auto
+        threshold: 2%
 
 parsers:
   gcov:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -25,9 +25,9 @@ jobs:
 
     - run: make testci
 
-    - uses: codecov/codecov-action@v1
+    - uses: codecov/codecov-action@v3
       with:
-        file: ./coverage.txt
+        files: ./coverage.txt
 
     - run: make image
 


### PR DESCRIPTION
Started seeing a deprecation warning on codecov comments ([e.g.](https://github.com/mccutchen/go-httpbin/pull/109#issuecomment-1408556422)):

> 📣 This organization is not using Codecov’s [GitHub App Integration](https://github.com/apps/codecov). We recommend you install it so Codecov can continue to function properly for your repositories. [Learn more](https://about.codecov.io/blog/codecov-is-updating-its-github-integration/?utm_medium=referral&utm_source=github&utm_content=comment&utm_campaign=pr+comments&utm_term=Will+McCutchen)

So, I installed the GitHub App integration.  Not sure what else is required, but this also seems like a good time to bump the GitHub Action we're using to the latest release.

Let's see what happens, I guess?