### PR TITLE
fix: properly handle /bytes/0

### DIFF
--- a/httpbin/handlers.go
+++ b/httpbin/handlers.go
@@ -785,9 +785,20 @@ func handleBytes(w http.ResponseWriter, r *http.Request, streaming bool) {
 		return
 	}
 
-	if numBytes < 1 {
-		numBytes = 1
-	} else if numBytes > 100*1024 {
+	if numBytes < 0 {
+		http.Error(w, "Bad Request", http.StatusBadRequest)
+		return
+	}
+
+	// Special case 0 bytes and exit early, since streaming & chunk size do not
+	// matter here.
+	if numBytes == 0 {
+		w.Header().Set("Content-Length", "0")
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	if numBytes > 100*1024 {
 		numBytes = 100 * 1024
 	}
 

--- a/httpbin/handlers_test.go
+++ b/httpbin/handlers_test.go
@@ -2455,7 +2455,8 @@ func TestBytes(t *testing.T) {
 		url                   string
 		expectedContentLength int
 	}{
-		{"/bytes/-1", 1},
+		{"/bytes/0", 0},
+		{"/bytes/1", 1},
 		{"/bytes/99999999", 100 * 1024},
 
 		// negative seed allowed
@@ -2480,6 +2481,8 @@ func TestBytes(t *testing.T) {
 		url            string
 		expectedStatus int
 	}{
+		{"/bytes/-1", http.StatusBadRequest},
+
 		{"/bytes", http.StatusNotFound},
 		{"/bytes/16/foo", http.StatusNotFound},
 


### PR DESCRIPTION
Fixes #112.

BREAKING CHANGE: Requests for zero bytes now actually return zero bytes. Requests for negative numbers of bytes are now rejected.