### PR TITLE
Fix #90 Return binary request bodies as base64 string

### DIFF
--- a/httpbin/helpers.go
+++ b/httpbin/helpers.go
@@ -159,6 +159,19 @@ func parseBody(w http.ResponseWriter, r *http.Request, resp *bodyResponse) error
 		if err != nil && err != io.EOF {
 			return err
 		}
+	// in case of binary data, we encode it as base64 and return it as a data url
+	case strings.HasPrefix(ct, "image/png"):
+		fallthrough
+	case strings.HasPrefix(ct, "image/jpeg"):
+		fallthrough
+	case strings.HasPrefix(ct, "image/webp"):
+		fallthrough
+	case strings.HasPrefix(ct, "application/octet-stream"):
+		data := base64.StdEncoding.EncodeToString(body)
+		if err != nil && err != io.EOF {
+			return err
+		}
+		resp.Data = string("data:application/octet-stream;base64," + data)
 	}
 
 	return nil


### PR DESCRIPTION
I implemented the binary encoding like it is done in the original httpbin #90.
I am not sure if the covered `Content-Type` are sufficient, but the list should be easy to extend.