### PR TITLE
Add websocket echo endpoint

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,8 @@
 module github.com/mccutchen/go-httpbin/v2
 
 go 1.16
+
+require (
+	golang.org/x/time v0.3.0
+	nhooyr.io/websocket v1.8.7
+)

--- a/httpbin/httpbin.go
+++ b/httpbin/httpbin.go
@@ -199,6 +199,9 @@ func (h *HTTPBin) Handler() http.Handler {
 	mux.HandleFunc("/uuid", h.UUID)
 	mux.HandleFunc("/base64/", h.Base64)
 
+	// websocket specific endpoints
+	mux.HandleFunc("/wscho", h.WebsocketEcho)
+
 	// existing httpbin endpoints that we do not support
 	mux.HandleFunc("/brotli", notImplementedHandler)
 

--- a/httpbin/middleware.go
+++ b/httpbin/middleware.go
@@ -1,8 +1,11 @@
 package httpbin
 
 import (
+	"bufio"
+	"errors"
 	"fmt"
 	"log"
+	"net"
 	"net/http"
 	"time"
 )
@@ -84,6 +87,14 @@ type metaResponseWriter struct {
 	w      http.ResponseWriter
 	status int
 	size   int64
+}
+
+func (mw *metaResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	h, ok := mw.w.(http.Hijacker)
+	if !ok {
+		return nil, nil, errors.New("hijack not supported")
+	}
+	return h.Hijack()
 }
 
 func (mw *metaResponseWriter) Write(b []byte) (int, error) {


### PR DESCRIPTION
Adds a handler at "/wscho" that accepts websocket upgrades and echoes any messages written to it. 

Inspired by the example set in https://github.com/nhooyr/websocket/tree/master/examples/echo