### PR TITLE
Return https if r.TLS is not nil

### DIFF
--- a/httpbin/helpers.go
+++ b/httpbin/helpers.go
@@ -59,6 +59,9 @@ func getURL(r *http.Request) *url.URL {
 	if scheme == "" && r.Header.Get("X-Forwarded-Ssl") == "on" {
 		scheme = "https"
 	}
+	if scheme == "" && r.TLS != nil {
+		scheme = "https"
+	}
 	if scheme == "" {
 		scheme = "http"
 	}


### PR DESCRIPTION
`go-httpbin` was incorrectly returning `http` as the scheme for its URL if you ran it with TLS specified via `HTTPS_CERT_FILE` and `HTTPS_KEY_FILE`. Update it to return https as the scheme in this case by checking if `r.TLS` is not nil

Before:

```
$ mkcert test
$ docker run -e HTTPS_CERT_FILE='/tmp/test.pem' -e HTTPS_KEY_FILE='/tmp/test-key.pem' -p 8080:8080 -v $(pwd):/tmp mccutchen/go-httpbin
$ curl -sk https://localhost:8080/get | jq -r .url
http://localhost:8080/get
```

After (TLS):

```
$ docker run -e HTTPS_CERT_FILE='/tmp/test.pem' -e HTTPS_KEY_FILE='/tmp/test-key.pem' -p 8080:8080 -v $(pwd):/tmp llimllib/go-httpbin
$ curl -sk https://localhost:8080/get | jq -r .url
https://localhost:8080/get
```

After (no TLS):

```
$ docker run -p 8080:8080 llimllib/go-httpbin
$ curl -sk http://localhost:8080/get | jq -r .url
http://localhost:8080/get
```

I got the idea for how to check the scheme from [this SO post](https://stackoverflow.com/a/61446922/42559)

**testing**: added a test for `getURL`
