### PR TITLE
populate files slice on multipart/form submission

### DIFF
--- a/httpbin/helpers.go
+++ b/httpbin/helpers.go
@@ -107,6 +107,8 @@ func writeHTML(w http.ResponseWriter, body []byte, status int) {
 	writeResponse(w, status, htmlContentType, body)
 }
 
+// parseFiles handles reading the contents of files in a multipart FileHeader
+// and returning a map that can be used as the Files attribute of a response
 func parseFiles(fileHeaders map[string][]*multipart.FileHeader) (map[string][]string, error) {
 	files := map[string][]string{}
 	for k, fs := range fileHeaders {

--- a/httpbin/helpers.go
+++ b/httpbin/helpers.go
@@ -122,7 +122,6 @@ func parseFiles(fileHeaders map[string][]*multipart.FileHeader) (map[string][]st
 				return nil, err
 			}
 			files[k] = append(files[k], string(contents))
-			fmt.Printf("file %s: %s %s\n", k, f.Filename, contents)
 		}
 	}
 	return files, nil

--- a/httpbin/helpers_test.go
+++ b/httpbin/helpers_test.go
@@ -3,6 +3,8 @@ package httpbin
 import (
 	"fmt"
 	"io"
+	"io/fs"
+	"mime/multipart"
 	"net/http"
 	"reflect"
 	"testing"
@@ -213,5 +215,23 @@ func Test_getClientIP(t *testing.T) {
 				t.Errorf("getClientIP() = %v, want %v", got, tc.want)
 			}
 		})
+	}
+}
+
+func TestParseFileDoesntExist(t *testing.T) {
+	// set up a headers map where the filename doesn't exist, to test `f.Open`
+	// throwing an error
+	headers := map[string][]*multipart.FileHeader{
+		"fieldname": {
+			{
+				Filename: "bananas",
+			},
+		},
+	}
+
+	// expect a patherror
+	_, err := parseFiles(headers)
+	if _, ok := err.(*fs.PathError); !ok {
+		t.Fatalf("Open(nonexist): error is %T, want *PathError", err)
 	}
 }


### PR DESCRIPTION
- populate files slice on multipart/form-data request
  - it was already present, but just wasn't filled out anywhere
- Is my test sufficient?
- How I'm currently integration testing this is by running this script:

```bash
printf "Hello World\n" > hello.txt
curl -s --request POST \
  --url http://0.0.0.0:8080/anything \
  --header 'content-type: multipart/form-data' \
  --form foo=@hello.txt \
  --form 'bar=Bonjour le monde' | jq .files

```

against a development server and expecting this output:

```json
{
  "foo": [
    "Hello World\n"
  ]
},
```
