### PR TITLE
Improve /drip semantics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ lint:
 # run locally
 # =============================================================================
 run: build
-	$(DIST_PATH)/go-httpbin
+	$(DIST_PATH)/go-httpbin -host 127.0.0.1 -port 8080
 .PHONY: run
 
 watch:

--- a/httpbin/handlers.go
+++ b/httpbin/handlers.go
@@ -654,13 +654,11 @@ func (h *HTTPBin) Drip(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Length", fmt.Sprintf("%d", numBytes))
 	w.WriteHeader(code)
 
-	flusher := w.(http.Flusher)
-	flusher.Flush()
-
 	// special case when we do not need to pause between each write
 	if pause == 0 {
-		b := bytes.Repeat([]byte{'*'}, int(numBytes))
-		w.Write(b)
+		for i := int64(0); i < numBytes; i++ {
+			w.Write([]byte{'*'})
+		}
 		return
 	}
 
@@ -669,6 +667,7 @@ func (h *HTTPBin) Drip(w http.ResponseWriter, r *http.Request) {
 	defer ticker.Stop()
 
 	b := []byte{'*'}
+	flusher := w.(http.Flusher)
 	for i := int64(0); i < numBytes; i++ {
 		w.Write(b)
 		flusher.Flush()

--- a/internal/testing/assert/assert.go
+++ b/internal/testing/assert/assert.go
@@ -6,14 +6,15 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/mccutchen/go-httpbin/v2/internal/testing/must"
 )
 
 // Equal asserts that two values are equal.
-func Equal[T comparable](t *testing.T, want, got T, msg string, arg ...any) {
+func Equal[T comparable](t *testing.T, got, want T, msg string, arg ...any) {
 	t.Helper()
-	if want != got {
+	if got != want {
 		if msg == "" {
 			msg = "expected values to match"
 		}
@@ -23,9 +24,9 @@ func Equal[T comparable](t *testing.T, want, got T, msg string, arg ...any) {
 }
 
 // DeepEqual asserts that two values are deeply equal.
-func DeepEqual[T any](t *testing.T, want, got T, msg string, arg ...any) {
+func DeepEqual[T any](t *testing.T, got, want T, msg string, arg ...any) {
 	t.Helper()
-	if !reflect.DeepEqual(want, got) {
+	if !reflect.DeepEqual(got, want) {
 		if msg == "" {
 			msg = "expected values to match"
 		}
@@ -88,4 +89,19 @@ func BodyEquals(t *testing.T, resp *http.Response, want string) {
 	t.Helper()
 	got := must.ReadAll(t, resp.Body)
 	Equal(t, got, want, "incorrect response body")
+}
+
+// DurationRange asserts that a duration is within a specific range.
+func DurationRange(t *testing.T, got, min, max time.Duration) {
+	t.Helper()
+	if got < min || got > max {
+		t.Fatalf("expected duration between %s and %s, got %s", min, max, got)
+	}
+}
+
+// RoughDuration asserts that a duration is within a certain tolerance of a
+// given value.
+func RoughDuration(t *testing.T, got, want time.Duration, tolerance time.Duration) {
+	t.Helper()
+	DurationRange(t, got, want-tolerance, want+tolerance)
 }


### PR DESCRIPTION
This started with me wading into the `/drip` endpoint to add `Server-Timing` trailers as suggested in https://github.com/mccutchen/go-httpbin/issues/72.

In making those changes, I discovered that the standard golang net/http server we're building on only supports sending trailers when the response is written using `Content-Encoding: chunked`.  Initially, I thought it would be reasonable for this endpoint, which is designed to stream writes to the client, to switch over to a chunked response, but upon further consideration I don't think that's a good idea.  So I'll defer adding trailers to some later work.

But, in thinking this through (and fighting with the unit tests already in place for drip), I realized that the `/drip` endpoint had room for improvement, if we think about it as an endpoint _designed to let clients test their behavior when an HTTP server is responding very slowly_.

So, we ended up with these changes:

- **Initial delay semantics**
  - Originally, `/drip` would immediately write the desired status code and then wait for the initial delay (if any).
  - Here we update that so that it waits for the initial delay before writing anything to the response, to better simulate a server that is just very slow to respond at all.
- **Incremental write timings**
  - Switch over to a ticker to more accurately pace the incremental writes across the requested duration
  - Stop sleeping after the final byte is written (should not affect clients, but avoids wasting server resources)

Worth noting that I now believe it's important that this endpoint **not** switch over to chunked content encoding, because it is useful to maintain and endpoint that simulates a server very slowly writing a "normal" HTTP response.

I'll consider adding trailers to an existing chunked endpoint, or potentially add a new, explicitly chunked endpoint to exercise that functionality.