### PR TITLE
feat: allow filtering incoming request headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ variables (or a combination of the two):
 | `-max-duration` | `MAX_DURATION` | Maximum duration a response may take | 10s |
 | `-port` | `PORT` | Port to listen on | 8080 |
 | `-use-real-hostname` | `USE_REAL_HOSTNAME` | Expose real hostname as reported by os.Hostname() in the /hostname endpoint | false |
+| `-exclude-headers` | `EXCLUDE_HEADERS` | Drop platform-specific headers. Comma-separated list of headers key to drop, supporting wildcard matching. For example: `"foo,bar,x-fc-*"` | - |
 
 **Notes:**
 - Command line arguments take precedence over environment variables.

--- a/README.md
+++ b/README.md
@@ -160,6 +160,13 @@ public internet, consider tuning it appropriately:
      logging using [zerolog] and further hardens the HTTP server against
      malicious clients by tuning lower-level timeouts and limits.
 
+5. **Prevent leaking sensitive headers**
+
+  By default, go-httpbin will return any headers sent by the client in the response.
+  But if you want to deploy go-httpbin in some serverless environment, you may want to drop some headers.
+  You can use the `-exclude-headers` CLI argument or the `EXCLUDE_HEADERS` env var to configure an appropriate allowlist.
+  For example, Alibaba Cloud Function Compute will [add some headers like `x-fc-*` to the request](https://www.alibabacloud.com/help/en/fc/user-guide/specification-details). if you want to drop these `x-fc-*` headers, you can set `EXCLUDE_HEADERS=x-fc-*`.
+
 ## Development
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ variables (or a combination of the two):
 | `-max-duration` | `MAX_DURATION` | Maximum duration a response may take | 10s |
 | `-port` | `PORT` | Port to listen on | 8080 |
 | `-use-real-hostname` | `USE_REAL_HOSTNAME` | Expose real hostname as reported by os.Hostname() in the /hostname endpoint | false |
-| `-exclude-headers` | `EXCLUDE_HEADERS` | Drop platform-specific headers. Comma-separated list of headers key to drop, supporting wildcard matching. For example: `"foo,bar,x-fc-*"` | - |
+| `-exclude-headers` | `EXCLUDE_HEADERS` | Drop platform-specific headers. Comma-separated list of headers key to drop, supporting wildcard suffix matching. For example: `"foo,bar,x-fc-*"` | - |
 
 **Notes:**
 - Command line arguments take precedence over environment variables.

--- a/httpbin/cmd/cmd.go
+++ b/httpbin/cmd/cmd.go
@@ -142,7 +142,7 @@ func loadConfig(args []string, getEnv func(string) string, getHostname func() (s
 	fs.StringVar(&cfg.ListenHost, "host", defaultListenHost, "Host to listen on")
 	fs.StringVar(&cfg.TLSCertFile, "https-cert-file", "", "HTTPS Server certificate file")
 	fs.StringVar(&cfg.TLSKeyFile, "https-key-file", "", "HTTPS Server private key file")
-	fs.StringVar(&cfg.ExcludeHeaders, "exclude-headers", "", "Drop platform-specific headers. Comma-separated list of headers key to drop. including wildcard prefix matches.")
+	fs.StringVar(&cfg.ExcludeHeaders, "exclude-headers", "", "Drop platform-specific headers. Comma-separated list of headers key to drop, supporting wildcard matching.")
 
 	// in order to fully control error output whether CLI arguments or env vars
 	// are used to configure the app, we need to take control away from the

--- a/httpbin/cmd/cmd.go
+++ b/httpbin/cmd/cmd.go
@@ -69,6 +69,7 @@ func mainImpl(args []string, getEnv func(string) string, getHostname func() (str
 		httpbin.WithMaxBodySize(cfg.MaxBodySize),
 		httpbin.WithMaxDuration(cfg.MaxDuration),
 		httpbin.WithObserver(httpbin.StdLogObserver(logger)),
+		httpbin.WithExcludeHeaders(cfg.ExcludeHeaders),
 	}
 	if cfg.RealHostname != "" {
 		opts = append(opts, httpbin.WithHostname(cfg.RealHostname))
@@ -99,6 +100,7 @@ func mainImpl(args []string, getEnv func(string) string, getHostname func() (str
 type config struct {
 	AllowedRedirectDomains []string
 	ListenHost             string
+	ExcludeHeaders         string
 	ListenPort             int
 	MaxBodySize            int64
 	MaxDuration            time.Duration
@@ -140,6 +142,7 @@ func loadConfig(args []string, getEnv func(string) string, getHostname func() (s
 	fs.StringVar(&cfg.ListenHost, "host", defaultListenHost, "Host to listen on")
 	fs.StringVar(&cfg.TLSCertFile, "https-cert-file", "", "HTTPS Server certificate file")
 	fs.StringVar(&cfg.TLSKeyFile, "https-key-file", "", "HTTPS Server private key file")
+	fs.StringVar(&cfg.ExcludeHeaders, "exclude-headers", "", "Drop platform-specific headers. Comma-separated list of headers key to drop. including wildcard prefix matches.")
 
 	// in order to fully control error output whether CLI arguments or env vars
 	// are used to configure the app, we need to take control away from the
@@ -188,6 +191,9 @@ func loadConfig(args []string, getEnv func(string) string, getHostname func() (s
 	}
 	if cfg.ListenHost == defaultListenHost && getEnv("HOST") != "" {
 		cfg.ListenHost = getEnv("HOST")
+	}
+	if cfg.ExcludeHeaders == "" && getEnv("EXCLUDE_HEADERS") != "" {
+		cfg.ExcludeHeaders = getEnv("EXCLUDE_HEADERS")
 	}
 	if cfg.ListenPort == defaultListenPort && getEnv("PORT") != "" {
 		cfg.ListenPort, err = strconv.Atoi(getEnv("PORT"))

--- a/httpbin/cmd/cmd_test.go
+++ b/httpbin/cmd/cmd_test.go
@@ -17,6 +17,8 @@ import (
 const usage = `Usage of go-httpbin:
   -allowed-redirect-domains string
     	Comma-separated list of domains the /redirect-to endpoint will allow
+  -exclude-headers string
+    	Drop platform-specific headers. Comma-separated list of headers key to drop, supporting wildcard matching.
   -host string
     	Host to listen on (default "0.0.0.0")
   -https-cert-file string

--- a/httpbin/handlers.go
+++ b/httpbin/handlers.go
@@ -47,7 +47,7 @@ func (h *HTTPBin) UTF8(w http.ResponseWriter, r *http.Request) {
 func (h *HTTPBin) Get(w http.ResponseWriter, r *http.Request) {
 	writeJSON(http.StatusOK, w, &noBodyResponse{
 		Args:    r.URL.Query(),
-		Headers: getRequestHeaders(r),
+		Headers: getRequestHeaders(r, h.Interceptor.Header),
 		Method:  r.Method,
 		Origin:  getClientIP(r),
 		URL:     getURL(r).String(),
@@ -74,7 +74,7 @@ func (h *HTTPBin) RequestWithBody(w http.ResponseWriter, r *http.Request) {
 		Args:    r.URL.Query(),
 		Files:   nilValues,
 		Form:    nilValues,
-		Headers: getRequestHeaders(r),
+		Headers: getRequestHeaders(r, h.Interceptor.Header),
 		Method:  r.Method,
 		Origin:  getClientIP(r),
 		URL:     getURL(r).String(),
@@ -96,7 +96,7 @@ func (h *HTTPBin) Gzip(w http.ResponseWriter, r *http.Request) {
 	)
 	mustMarshalJSON(gzw, &noBodyResponse{
 		Args:    r.URL.Query(),
-		Headers: getRequestHeaders(r),
+		Headers: getRequestHeaders(r, h.Interceptor.Header),
 		Method:  r.Method,
 		Origin:  getClientIP(r),
 		Gzipped: true,
@@ -119,7 +119,7 @@ func (h *HTTPBin) Deflate(w http.ResponseWriter, r *http.Request) {
 	)
 	mustMarshalJSON(zw, &noBodyResponse{
 		Args:     r.URL.Query(),
-		Headers:  getRequestHeaders(r),
+		Headers:  getRequestHeaders(r, h.Interceptor.Header),
 		Method:   r.Method,
 		Origin:   getClientIP(r),
 		Deflated: true,
@@ -151,7 +151,7 @@ func (h *HTTPBin) UserAgent(w http.ResponseWriter, r *http.Request) {
 // Headers echoes the incoming request headers
 func (h *HTTPBin) Headers(w http.ResponseWriter, r *http.Request) {
 	writeJSON(http.StatusOK, w, &headersResponse{
-		Headers: getRequestHeaders(r),
+		Headers: getRequestHeaders(r, h.Interceptor.Header),
 	})
 }
 
@@ -538,7 +538,7 @@ func (h *HTTPBin) Stream(w http.ResponseWriter, r *http.Request) {
 
 	resp := &streamResponse{
 		Args:    r.URL.Query(),
-		Headers: getRequestHeaders(r),
+		Headers: getRequestHeaders(r, h.Interceptor.Header),
 		Origin:  getClientIP(r),
 		URL:     getURL(r).String(),
 	}
@@ -783,7 +783,7 @@ func (h *HTTPBin) ETag(w http.ResponseWriter, r *http.Request) {
 	var buf bytes.Buffer
 	mustMarshalJSON(&buf, noBodyResponse{
 		Args:    r.URL.Query(),
-		Headers: getRequestHeaders(r),
+		Headers: getRequestHeaders(r, h.Interceptor.Header),
 		Method:  r.Method,
 		Origin:  getClientIP(r),
 		URL:     getURL(r).String(),

--- a/httpbin/handlers.go
+++ b/httpbin/handlers.go
@@ -47,7 +47,7 @@ func (h *HTTPBin) UTF8(w http.ResponseWriter, r *http.Request) {
 func (h *HTTPBin) Get(w http.ResponseWriter, r *http.Request) {
 	writeJSON(http.StatusOK, w, &noBodyResponse{
 		Args:    r.URL.Query(),
-		Headers: getRequestHeaders(r, h.headersProcessor),
+		Headers: getRequestHeaders(r, h.excludeHeadersProcessor),
 		Method:  r.Method,
 		Origin:  getClientIP(r),
 		URL:     getURL(r).String(),
@@ -74,7 +74,7 @@ func (h *HTTPBin) RequestWithBody(w http.ResponseWriter, r *http.Request) {
 		Args:    r.URL.Query(),
 		Files:   nilValues,
 		Form:    nilValues,
-		Headers: getRequestHeaders(r, h.headersProcessor),
+		Headers: getRequestHeaders(r, h.excludeHeadersProcessor),
 		Method:  r.Method,
 		Origin:  getClientIP(r),
 		URL:     getURL(r).String(),
@@ -96,7 +96,7 @@ func (h *HTTPBin) Gzip(w http.ResponseWriter, r *http.Request) {
 	)
 	mustMarshalJSON(gzw, &noBodyResponse{
 		Args:    r.URL.Query(),
-		Headers: getRequestHeaders(r, h.headersProcessor),
+		Headers: getRequestHeaders(r, h.excludeHeadersProcessor),
 		Method:  r.Method,
 		Origin:  getClientIP(r),
 		Gzipped: true,
@@ -119,7 +119,7 @@ func (h *HTTPBin) Deflate(w http.ResponseWriter, r *http.Request) {
 	)
 	mustMarshalJSON(zw, &noBodyResponse{
 		Args:     r.URL.Query(),
-		Headers:  getRequestHeaders(r, h.headersProcessor),
+		Headers:  getRequestHeaders(r, h.excludeHeadersProcessor),
 		Method:   r.Method,
 		Origin:   getClientIP(r),
 		Deflated: true,
@@ -151,7 +151,7 @@ func (h *HTTPBin) UserAgent(w http.ResponseWriter, r *http.Request) {
 // Headers echoes the incoming request headers
 func (h *HTTPBin) Headers(w http.ResponseWriter, r *http.Request) {
 	writeJSON(http.StatusOK, w, &headersResponse{
-		Headers: getRequestHeaders(r, h.headersProcessor),
+		Headers: getRequestHeaders(r, h.excludeHeadersProcessor),
 	})
 }
 
@@ -538,7 +538,7 @@ func (h *HTTPBin) Stream(w http.ResponseWriter, r *http.Request) {
 
 	resp := &streamResponse{
 		Args:    r.URL.Query(),
-		Headers: getRequestHeaders(r, h.headersProcessor),
+		Headers: getRequestHeaders(r, h.excludeHeadersProcessor),
 		Origin:  getClientIP(r),
 		URL:     getURL(r).String(),
 	}
@@ -783,7 +783,7 @@ func (h *HTTPBin) ETag(w http.ResponseWriter, r *http.Request) {
 	var buf bytes.Buffer
 	mustMarshalJSON(&buf, noBodyResponse{
 		Args:    r.URL.Query(),
-		Headers: getRequestHeaders(r, h.headersProcessor),
+		Headers: getRequestHeaders(r, h.excludeHeadersProcessor),
 		Method:  r.Method,
 		Origin:  getClientIP(r),
 		URL:     getURL(r).String(),

--- a/httpbin/handlers.go
+++ b/httpbin/handlers.go
@@ -47,7 +47,7 @@ func (h *HTTPBin) UTF8(w http.ResponseWriter, r *http.Request) {
 func (h *HTTPBin) Get(w http.ResponseWriter, r *http.Request) {
 	writeJSON(http.StatusOK, w, &noBodyResponse{
 		Args:    r.URL.Query(),
-		Headers: getRequestHeaders(r, h.Interceptor.Header),
+		Headers: getRequestHeaders(r, h.HeadersProcessor),
 		Method:  r.Method,
 		Origin:  getClientIP(r),
 		URL:     getURL(r).String(),
@@ -74,7 +74,7 @@ func (h *HTTPBin) RequestWithBody(w http.ResponseWriter, r *http.Request) {
 		Args:    r.URL.Query(),
 		Files:   nilValues,
 		Form:    nilValues,
-		Headers: getRequestHeaders(r, h.Interceptor.Header),
+		Headers: getRequestHeaders(r, h.HeadersProcessor),
 		Method:  r.Method,
 		Origin:  getClientIP(r),
 		URL:     getURL(r).String(),
@@ -96,7 +96,7 @@ func (h *HTTPBin) Gzip(w http.ResponseWriter, r *http.Request) {
 	)
 	mustMarshalJSON(gzw, &noBodyResponse{
 		Args:    r.URL.Query(),
-		Headers: getRequestHeaders(r, h.Interceptor.Header),
+		Headers: getRequestHeaders(r, h.HeadersProcessor),
 		Method:  r.Method,
 		Origin:  getClientIP(r),
 		Gzipped: true,
@@ -119,7 +119,7 @@ func (h *HTTPBin) Deflate(w http.ResponseWriter, r *http.Request) {
 	)
 	mustMarshalJSON(zw, &noBodyResponse{
 		Args:     r.URL.Query(),
-		Headers:  getRequestHeaders(r, h.Interceptor.Header),
+		Headers:  getRequestHeaders(r, h.HeadersProcessor),
 		Method:   r.Method,
 		Origin:   getClientIP(r),
 		Deflated: true,
@@ -151,7 +151,7 @@ func (h *HTTPBin) UserAgent(w http.ResponseWriter, r *http.Request) {
 // Headers echoes the incoming request headers
 func (h *HTTPBin) Headers(w http.ResponseWriter, r *http.Request) {
 	writeJSON(http.StatusOK, w, &headersResponse{
-		Headers: getRequestHeaders(r, h.Interceptor.Header),
+		Headers: getRequestHeaders(r, h.HeadersProcessor),
 	})
 }
 
@@ -538,7 +538,7 @@ func (h *HTTPBin) Stream(w http.ResponseWriter, r *http.Request) {
 
 	resp := &streamResponse{
 		Args:    r.URL.Query(),
-		Headers: getRequestHeaders(r, h.Interceptor.Header),
+		Headers: getRequestHeaders(r, h.HeadersProcessor),
 		Origin:  getClientIP(r),
 		URL:     getURL(r).String(),
 	}
@@ -783,7 +783,7 @@ func (h *HTTPBin) ETag(w http.ResponseWriter, r *http.Request) {
 	var buf bytes.Buffer
 	mustMarshalJSON(&buf, noBodyResponse{
 		Args:    r.URL.Query(),
-		Headers: getRequestHeaders(r, h.Interceptor.Header),
+		Headers: getRequestHeaders(r, h.HeadersProcessor),
 		Method:  r.Method,
 		Origin:  getClientIP(r),
 		URL:     getURL(r).String(),

--- a/httpbin/handlers.go
+++ b/httpbin/handlers.go
@@ -47,7 +47,7 @@ func (h *HTTPBin) UTF8(w http.ResponseWriter, r *http.Request) {
 func (h *HTTPBin) Get(w http.ResponseWriter, r *http.Request) {
 	writeJSON(http.StatusOK, w, &noBodyResponse{
 		Args:    r.URL.Query(),
-		Headers: getRequestHeaders(r, h.HeadersProcessor),
+		Headers: getRequestHeaders(r, h.headersProcessor),
 		Method:  r.Method,
 		Origin:  getClientIP(r),
 		URL:     getURL(r).String(),
@@ -74,7 +74,7 @@ func (h *HTTPBin) RequestWithBody(w http.ResponseWriter, r *http.Request) {
 		Args:    r.URL.Query(),
 		Files:   nilValues,
 		Form:    nilValues,
-		Headers: getRequestHeaders(r, h.HeadersProcessor),
+		Headers: getRequestHeaders(r, h.headersProcessor),
 		Method:  r.Method,
 		Origin:  getClientIP(r),
 		URL:     getURL(r).String(),
@@ -96,7 +96,7 @@ func (h *HTTPBin) Gzip(w http.ResponseWriter, r *http.Request) {
 	)
 	mustMarshalJSON(gzw, &noBodyResponse{
 		Args:    r.URL.Query(),
-		Headers: getRequestHeaders(r, h.HeadersProcessor),
+		Headers: getRequestHeaders(r, h.headersProcessor),
 		Method:  r.Method,
 		Origin:  getClientIP(r),
 		Gzipped: true,
@@ -119,7 +119,7 @@ func (h *HTTPBin) Deflate(w http.ResponseWriter, r *http.Request) {
 	)
 	mustMarshalJSON(zw, &noBodyResponse{
 		Args:     r.URL.Query(),
-		Headers:  getRequestHeaders(r, h.HeadersProcessor),
+		Headers:  getRequestHeaders(r, h.headersProcessor),
 		Method:   r.Method,
 		Origin:   getClientIP(r),
 		Deflated: true,
@@ -151,7 +151,7 @@ func (h *HTTPBin) UserAgent(w http.ResponseWriter, r *http.Request) {
 // Headers echoes the incoming request headers
 func (h *HTTPBin) Headers(w http.ResponseWriter, r *http.Request) {
 	writeJSON(http.StatusOK, w, &headersResponse{
-		Headers: getRequestHeaders(r, h.HeadersProcessor),
+		Headers: getRequestHeaders(r, h.headersProcessor),
 	})
 }
 
@@ -538,7 +538,7 @@ func (h *HTTPBin) Stream(w http.ResponseWriter, r *http.Request) {
 
 	resp := &streamResponse{
 		Args:    r.URL.Query(),
-		Headers: getRequestHeaders(r, h.HeadersProcessor),
+		Headers: getRequestHeaders(r, h.headersProcessor),
 		Origin:  getClientIP(r),
 		URL:     getURL(r).String(),
 	}
@@ -783,7 +783,7 @@ func (h *HTTPBin) ETag(w http.ResponseWriter, r *http.Request) {
 	var buf bytes.Buffer
 	mustMarshalJSON(&buf, noBodyResponse{
 		Args:    r.URL.Query(),
-		Headers: getRequestHeaders(r, h.HeadersProcessor),
+		Headers: getRequestHeaders(r, h.headersProcessor),
 		Method:  r.Method,
 		Origin:  getClientIP(r),
 		URL:     getURL(r).String(),

--- a/httpbin/handlers_test.go
+++ b/httpbin/handlers_test.go
@@ -202,7 +202,6 @@ func TestGet(t *testing.T) {
 		assertHeader(t, &result.Headers, "X-Ignore-Foo", "")
 		assertHeader(t, &result.Headers, "X-Info-Foo", "bar")
 		assertHeader(t, &result.Headers, "X-Info", "intercepted")
-
 	})
 
 	t.Run("only_allows_gets", func(t *testing.T) {

--- a/httpbin/helpers.go
+++ b/httpbin/helpers.go
@@ -13,6 +13,7 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/url"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -21,6 +22,8 @@ import (
 
 // Base64MaxLen - Maximum input length for Base64 functions
 const Base64MaxLen = 2000
+
+type HeaderInterceptor func(h http.Header) http.Header
 
 // requestHeaders takes in incoming request and returns an http.Header map
 // suitable for inclusion in our response data structures.
@@ -435,4 +438,25 @@ func (b *base64Helper) Encode() ([]byte, error) {
 // Decode - decode data from base64
 func (b *base64Helper) Decode() ([]byte, error) {
 	return base64.URLEncoding.DecodeString(b.data)
+}
+
+func wildCardToRegexp(pattern string) string {
+	components := strings.Split(pattern, "*")
+	if len(components) == 1 {
+		// if len is 1, there are no *'s, return exact match pattern
+		return "^" + pattern + "$"
+	}
+	var result strings.Builder
+	for i, literal := range components {
+
+		// Replace * with .*
+		if i > 0 {
+			result.WriteString(".*")
+		}
+
+		// Quote any regular expression meta characters in the
+		// literal text.
+		result.WriteString(regexp.QuoteMeta(literal))
+	}
+	return "^" + result.String() + "$"
 }

--- a/httpbin/helpers.go
+++ b/httpbin/helpers.go
@@ -28,11 +28,14 @@ const Base64MaxLen = 2000
 // This is necessary to ensure that the incoming Host and Transfer-Encoding
 // headers are included, because golang only exposes those values on the
 // http.Request struct itself.
-func getRequestHeaders(r *http.Request) http.Header {
+func getRequestHeaders(r *http.Request, fn HeaderInterceptor) http.Header {
 	h := r.Header
 	h.Set("Host", r.Host)
 	if len(r.TransferEncoding) > 0 {
 		h.Set("Transfer-Encoding", strings.Join(r.TransferEncoding, ","))
+	}
+	if fn != nil {
+		return fn(h)
 	}
 	return h
 }

--- a/httpbin/helpers.go
+++ b/httpbin/helpers.go
@@ -478,10 +478,14 @@ func createFullExcludeRegex(excludeHeaders string) *regexp.Regexp {
 	// comma separated list of headers to exclude from response
 	tmp := strings.Split(excludeHeaders, ",")
 
-	tmpRegexStrings := make([]string, len(tmp))
-	for i, v := range tmp {
-		pattern := wildCardToRegexp(strings.TrimSpace(v))
-		tmpRegexStrings[i] = pattern
+	tmpRegexStrings := make([]string, 0)
+	for _, v := range tmp {
+		s := strings.TrimSpace(v)
+		if len(s) == 0 {
+			continue
+		}
+		pattern := wildCardToRegexp(s)
+		tmpRegexStrings = append(tmpRegexStrings, pattern)
 	}
 
 	if len(tmpRegexStrings) > 0 {

--- a/httpbin/helpers.go
+++ b/httpbin/helpers.go
@@ -459,11 +459,11 @@ func wildCardToRegexp(pattern string) string {
 	return "^" + result.String() + "$"
 }
 
-func createHeadersProcessor(regex *regexp.Regexp) headersProcessorFunc {
+func createExcludeHeadersProcessor(excludeRegex *regexp.Regexp) headersProcessorFunc {
 	return func(headers http.Header) http.Header {
 		result := make(http.Header)
 		for k, v := range headers {
-			matched := regex.Match([]byte(k))
+			matched := excludeRegex.Match([]byte(k))
 			if matched {
 				continue
 			}

--- a/httpbin/helpers_test.go
+++ b/httpbin/helpers_test.go
@@ -313,7 +313,8 @@ func TestWildcardHelpers(t *testing.T) {
 }
 
 func TestCreateFullExcludeRegex(t *testing.T) {
-	excludeHeaders := "x-ignore-*,x-info-this-key"
+	// tolerate unused comma
+	excludeHeaders := "x-ignore-*,x-info-this-key,,"
 	regex := createFullExcludeRegex(excludeHeaders)
 	fmt.Printf("regex: %v\n", regex)
 	tests := []struct {
@@ -354,4 +355,7 @@ func TestCreateFullExcludeRegex(t *testing.T) {
 			assert.Equal(t, matched, test.expected, "incorrect match")
 		})
 	}
+
+	nilReturn := createFullExcludeRegex("")
+	assert.Equal(t, nilReturn, nil, "incorrect match")
 }

--- a/httpbin/helpers_test.go
+++ b/httpbin/helpers_test.go
@@ -279,33 +279,60 @@ func TestParseFileDoesntExist(t *testing.T) {
 }
 
 func TestWildcardHelpers(t *testing.T) {
-	tmpRegexStr := wildCardToRegexp("info-*")
-	regex := regexp.MustCompile("(?i)" + "(" + tmpRegexStr + ")")
-
 	tests := []struct {
+		pattern  string
 		name     string
 		input    string
 		expected bool
 	}{
 		{
+			"info-*",
 			"basic test",
 			"info-foo",
 			true,
 		},
 		{
+			"info-*",
 			"basic test case insensitive",
 			"INFO-bar",
 			true,
 		},
 		{
-			"basic test 3",
-			"foo-bar",
+			"info-*-foo",
+			"a single wildcard in the middle of the string",
+			"INFO-bar-foo",
+			true,
+		},
+		{
+			"info-*-foo",
+			"a single wildcard in the middle of the string",
+			"INFO-bar-baz",
+			false,
+		},
+		{
+			"info-*-foo-*-bar",
+			"multiple wildcards in the string",
+			"info-aaa-foo--bar",
+			true,
+		},
+		{
+			"info-*-foo-*-bar",
+			"multiple wildcards in the string",
+			"info-aaa-foo-a-bar",
+			true,
+		},
+		{
+			"info-*-foo-*-bar",
+			"multiple wildcards in the string",
+			"info-aaa-foo--bar123",
 			false,
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			tmpRegexStr := wildCardToRegexp(test.pattern)
+			regex := regexp.MustCompile("(?i)" + "(" + tmpRegexStr + ")")
 			matched := regex.Match([]byte(test.input))
 			assert.Equal(t, matched, test.expected, "incorrect match")
 		})
@@ -316,7 +343,6 @@ func TestCreateFullExcludeRegex(t *testing.T) {
 	// tolerate unused comma
 	excludeHeaders := "x-ignore-*,x-info-this-key,,"
 	regex := createFullExcludeRegex(excludeHeaders)
-	fmt.Printf("regex: %v\n", regex)
 	tests := []struct {
 		name     string
 		input    string

--- a/httpbin/httpbin.go
+++ b/httpbin/httpbin.go
@@ -55,7 +55,7 @@ type HTTPBin struct {
 	// The app's http handler
 	handler http.Handler
 
-	headersProcessor headersProcessorFunc
+	excludeHeadersProcessor headersProcessorFunc
 }
 
 // New creates a new HTTPBin instance
@@ -188,6 +188,6 @@ func (h *HTTPBin) Handler() http.Handler {
 func (h *HTTPBin) setExcludeHeaders(excludeHeaders string) {
 	regex := createFullExcludeRegex(excludeHeaders)
 	if regex != nil {
-		h.headersProcessor = createHeadersProcessor(regex)
+		h.excludeHeadersProcessor = createExcludeHeadersProcessor(regex)
 	}
 }

--- a/httpbin/httpbin.go
+++ b/httpbin/httpbin.go
@@ -27,6 +27,12 @@ var DefaultDefaultParams = DefaultParams{
 	DripNumBytes: 10,
 }
 
+type HeaderInterceptor func(h http.Header) http.Header
+
+type Interceptor struct {
+	Header HeaderInterceptor
+}
+
 // HTTPBin contains the business logic
 type HTTPBin struct {
 	// Max size of an incoming request generated response body, in bytes
@@ -44,6 +50,9 @@ type HTTPBin struct {
 
 	// Set of hosts to which the /redirect-to endpoint will allow redirects
 	AllowedRedirectDomains map[string]struct{}
+
+	Interceptor Interceptor
+
 	forbiddenRedirectError string
 
 	// The hostname to expose via /hostname.

--- a/httpbin/options.go
+++ b/httpbin/options.go
@@ -46,9 +46,9 @@ func WithObserver(o Observer) OptionFunc {
 	}
 }
 
-func WithInterceptor(i Interceptor) OptionFunc {
+func WithExcludeHeaders(excludeHeaders string) OptionFunc {
 	return func(h *HTTPBin) {
-		h.Interceptor = i
+		h.SetExcludeHeaders(excludeHeaders)
 	}
 }
 

--- a/httpbin/options.go
+++ b/httpbin/options.go
@@ -46,6 +46,12 @@ func WithObserver(o Observer) OptionFunc {
 	}
 }
 
+func WithInterceptor(i Interceptor) OptionFunc {
+	return func(h *HTTPBin) {
+		h.Interceptor = i
+	}
+}
+
 // WithAllowedRedirectDomains limits the domains to which the /redirect-to
 // endpoint will redirect traffic.
 func WithAllowedRedirectDomains(hosts []string) OptionFunc {

--- a/httpbin/options.go
+++ b/httpbin/options.go
@@ -48,7 +48,7 @@ func WithObserver(o Observer) OptionFunc {
 
 func WithExcludeHeaders(excludeHeaders string) OptionFunc {
 	return func(h *HTTPBin) {
-		h.SetExcludeHeaders(excludeHeaders)
+		h.setExcludeHeaders(excludeHeaders)
 	}
 }
 


### PR DESCRIPTION
I want to deploy go-httpbin to Alibaba Cloud Function Compute (A Serverless Runtime), But in FC, the Server will add some custom header on the request headers:

for example:
![CleanShot 2023-07-21 at 12 50 06@2x](https://github.com/mccutchen/go-httpbin/assets/13938334/c2dd08a1-3a8a-4e72-a421-645c4321ab34)


So I add this logic to process unused headers:

```golang
	opts := []httpbin.OptionFunc{
		httpbin.WithMaxBodySize(cfg.MaxBodySize),
		httpbin.WithMaxDuration(cfg.MaxDuration),
		httpbin.WithObserver(httpbin.StdLogObserver(logger)),
		httpbin.WithExcludeHeaders("x-ignore-*,x-info-this-key"),
	}
```
