### PR TITLE
feat: add a kustomize base to the repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,14 @@ $ docker run -P mccutchen/go-httpbin
 $ docker run -e HTTPS_CERT_FILE='/tmp/server.crt' -e HTTPS_KEY_FILE='/tmp/server.key' -p 8080:8080 -v /tmp:/tmp mccutchen/go-httpbin
 ```
 
+### Kubernetes
+
+```
+$ kubectl apply -k github.com/mccutchen/go-httpbin/kustomize
+```
+
+See `./kustomize` directory for further information
+
 ### Standalone binary
 
 Follow the [Installation](#installation) instructions to install go-httpbin as

--- a/kustomize/README.md
+++ b/kustomize/README.md
@@ -1,0 +1,39 @@
+This folder is a [kustomize application](https://kubectl.docs.kubernetes.io/references/kustomize/glossary/#application) that stands up a running instance of go-httpbin in a Kubernetes cluster.
+
+You may wish to utilise this as a [remote application](https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/resource/), e.g.
+
+```yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+commonLabels:
+  app.kubernetes.io/name: httpbin
+resources:
+  - github.com/mccutchen/go-httpbin/kustomize
+images:
+  - name: mccutchen/go-httpbin
+```
+
+To expose your instance to the internet, you could add an `Ingress` in an overlay:
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: httpbin
+spec:
+  ingressClassName: myingressname
+  rules:
+    - host: my-go-httpbin.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: httpbin
+                port:
+                  name: http
+  tls:
+   - hosts:
+       - my-go-httpbin.com
+     secretName: go-httpbin-tls
+```

--- a/kustomize/kustomization.yaml
+++ b/kustomize/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+commonLabels:
+  app.kubernetes.io/name: httpbin
+resources:
+  - resources.yaml
+images:
+  - name: mccutchen/go-httpbin

--- a/kustomize/resources.yaml
+++ b/kustomize/resources.yaml
@@ -1,0 +1,34 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: httpbin
+spec:
+  template:
+    spec:
+      containers:
+        - name: httpbin
+          image: mccutchen/go-httpbin
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /status/200
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /status/200
+              port: http
+          resources: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: httpbin
+spec:
+  ports:
+    - port: 80
+      targetPort: http
+      protocol: TCP
+      name: http


### PR DESCRIPTION
Adds a [kustomize application](https://kubectl.docs.kubernetes.io/references/kustomize/glossary/#application) that stands up a running instance of go-httpbin in a Kubernetes cluster.

This is useful to reference as a remote kustomization via your own kustomization, or can be used as:
`kustomize build github.com/mccutchen/go-httpbin/kustomize | kubectl apply -f -`
or even as:  `kubectl apply -k github.com/mccutchen/go-httpbin/kustomize`