### PR TITLE
fix fork ribbon

### DIFF
--- a/httpbin/handlers.go
+++ b/httpbin/handlers.go
@@ -29,7 +29,7 @@ func (h *HTTPBin) Index(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusNotFound, nil)
 		return
 	}
-	w.Header().Set("Content-Security-Policy", "default-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' camo.githubusercontent.com")
+	w.Header().Set("Content-Security-Policy", "default-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' github.blog")
 	writeHTML(w, mustStaticAsset("index.html"), http.StatusOK)
 }
 

--- a/httpbin/handlers_test.go
+++ b/httpbin/handlers_test.go
@@ -76,7 +76,7 @@ func TestIndex(t *testing.T) {
 		resp := must.DoReq(t, client, req)
 
 		assert.ContentType(t, resp, htmlContentType)
-		assert.Header(t, resp, "Content-Security-Policy", "default-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' camo.githubusercontent.com")
+		assert.Header(t, resp, "Content-Security-Policy", "default-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' github.blog")
 		assert.BodyContains(t, resp, "go-httpbin")
 	})
 

--- a/httpbin/static/index.html
+++ b/httpbin/static/index.html
@@ -189,7 +189,7 @@ Content-Length: 0
 
 </div>
 
-<a href="https://github.com/mccutchen/go-httpbin"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/38ef81f8aca64bb9a64448d0d70f1308ef5341ab/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png"></a>
+<a href="https://github.com/mccutchen/go-httpbin"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github.blog/wp-content/uploads/2008/12/forkme_right_green_007200.png" alt="Fork me on GitHub" loading="lazy"></a>
 
 </body>
 </html>


### PR DESCRIPTION
The fork ribbon is not accessible anymore. 

This PR fixes it according to github blog entry : 
https://github.blog/2008-12-19-github-ribbons/ 

An alternative would be to use SVG and avoid external resources 
https://github.com/usecue/fork-me-on-github-svg-ribbons/blob/master/images/forkme_right_green_007200.svg?short_path=6c44517 
