### PR TITLE
fix: /base64 endpoint decodes both URL-safe and standard b64 encodings

### DIFF
--- a/httpbin/handlers_test.go
+++ b/httpbin/handlers_test.go
@@ -2708,6 +2708,13 @@ func TestBase64(t *testing.T) {
 			"abc123!?$*&()'-=@~",
 		},
 		{
+			// Std base64 is also supported for decoding (+ instead of - in
+			// encoded input string). See also:
+			// https://github.com/mccutchen/go-httpbin/issues/152
+			"/base64/decode/8J+Ziywg8J+MjSEK4oCm",
+			"🙋, 🌍!\n…",
+		},
+		{
 			// URL-safe base64 is used for encoding (note the - instead of + in
 			// encoded output string)
 			"/base64/encode/abc123%21%3F%24%2A%26%28%29%27-%3D%40~",
@@ -2763,12 +2770,6 @@ func TestBase64(t *testing.T) {
 		{
 			"/base64/unknown/dmFsaWRfYmFzZTY0X2VuY29kZWRfc3RyaW5n",
 			"invalid operation: unknown",
-		},
-		{
-			// we only support URL-safe base64 encoded strings (note the +
-			// instead of - in encoded input string)
-			"/base64/decode/YWJjMTIzIT8kKiYoKSctPUB+",
-			"illegal base64 data",
 		},
 	}
 

--- a/httpbin/helpers.go
+++ b/httpbin/helpers.go
@@ -429,16 +429,20 @@ func newBase64Helper(path string) (*base64Helper, error) {
 	return &b, nil
 }
 
-// Encode - encode data as base64
+// Encode - encode data as URL-safe base64
 func (b *base64Helper) Encode() ([]byte, error) {
 	buff := make([]byte, base64.URLEncoding.EncodedLen(len(b.data)))
 	base64.URLEncoding.Encode(buff, []byte(b.data))
 	return buff, nil
 }
 
-// Decode - decode data from base64
+// Decode - decode data from base64, attempting both URL-safe and standard
+// encodings.
 func (b *base64Helper) Decode() ([]byte, error) {
-	return base64.URLEncoding.DecodeString(b.data)
+	if result, err := base64.URLEncoding.DecodeString(b.data); err == nil {
+		return result, nil
+	}
+	return base64.StdEncoding.DecodeString(b.data)
 }
 
 func wildCardToRegexp(pattern string) string {

--- a/httpbin/static/index.html
+++ b/httpbin/static/index.html
@@ -61,9 +61,9 @@
 <li><a href="/"><code>/</code></a> This page.</li>
 <li><a href="/absolute-redirect/6"><code>/absolute-redirect/:n</code></a> 302 Absolute redirects <em>n</em> times.</li>
 <li><a href="/anything"><code>/anything/:anything</code></a> Returns anything that is passed to request.</li>
-<li><a href="/base64/aHR0cGJpbmdvLm9yZw=="><code>/base64/:value</code></a> Decodes a Base64 encoded string.</li>
+<li><a href="/base64/aHR0cGJpbmdvLm9yZw=="><code>/base64/:value</code></a> Decodes a Base64-encoded string.</li>
 <li><a href="/base64/decode/aHR0cGJpbmdvLm9yZw=="><code>/base64/decode/:value</code></a> Explicit URL for decoding a Base64 encoded string.</li>
-<li><a href="/base64/encode/httpbingo.org"><code>/base64/encode/:value</code></a> Encodes a string into Base64.</li>
+<li><a href="/base64/encode/httpbingo.org"><code>/base64/encode/:value</code></a> Encodes a string into URL-safe Base64.</li>
 <li><a href="/basic-auth/user/passwd"><code>/basic-auth/:user/:passwd</code></a> Challenges HTTPBasic Auth.</li>
 <li><a href="/bearer"><code>/bearer</code></a> Checks Bearer token header - returns 401 if not set.</li>
 <li><a href="/brotli"><code><del>/brotli</del></code></a> Returns brotli-encoded data.</del> <i>Not implemented!</i></li>


### PR DESCRIPTION
As reported in #152, the `/base64` endpoint can only decode the "URL-safe" base64 encoding, but the error it returns is not very useful if you're not already familiar with different base64 encoding variants.

Here we follow [Postel's law](https://en.wikipedia.org/wiki/Robustness_principle) and accept either the URL-safe or standard encodings, while continuing to use the URL-safe variant when encoding ourselves.

Fixes #152.