### PR TITLE
docs: update EXCLUDE_HEADERS documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,10 +163,22 @@ public internet, consider tuning it appropriately:
 
 5. **Prevent leaking sensitive headers**
 
-  By default, go-httpbin will return any headers sent by the client in the response.
-  But if you want to deploy go-httpbin in some serverless environment, you may want to drop some headers.
-  You can use the `-exclude-headers` CLI argument or the `EXCLUDE_HEADERS` env var to configure an appropriate allowlist.
-  For example, Alibaba Cloud Function Compute will [add some headers like `x-fc-*` to the request](https://www.alibabacloud.com/help/en/fc/user-guide/specification-details). if you want to drop these `x-fc-*` headers, you can set `EXCLUDE_HEADERS=x-fc-*`.
+   By default, go-httpbin will return any request headers sent by the client
+   (and any intermediate proxies) in the response. If go-httpbin is deployed
+   into an environment where some incoming request headers might reveal
+   sensitive information, use the `-exclude-headers` CLI argument or
+   `EXCLUDE_HEADERS` env var to configure a denylist of sensitive header keys.
+
+   For example, the Alibaba Cloud Function Compute platform adds [a variety of
+   `x-fc-*` headers][alibaba-headers] to each incoming request, some of which
+   might be sensitive. To have go-httpbin filter **all** of these headers in
+   its own responses, set
+
+       EXCLUDE_HEADERS="x-fc-*"
+
+   To have go-httpbin filter only specific headers, you can get more specific:
+
+       EXCLUDE_HEADERS="x-fc-access-key-*,x-fc-security-token,x-fc-region"
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -170,9 +170,9 @@ public internet, consider tuning it appropriately:
    `EXCLUDE_HEADERS` env var to configure a denylist of sensitive header keys.
 
    For example, the Alibaba Cloud Function Compute platform adds [a variety of
-   `x-fc-*` headers][alibaba-headers] to each incoming request, some of which
-   might be sensitive. To have go-httpbin filter **all** of these headers in
-   its own responses, set
+   headers][alibaba-headers] to each incoming request, some of which might be
+   sensitive. To have go-httpbin filter **all** of these headers in its own
+   responses, set
 
        EXCLUDE_HEADERS="x-fc-*"
 

--- a/README.md
+++ b/README.md
@@ -170,9 +170,9 @@ public internet, consider tuning it appropriately:
    `EXCLUDE_HEADERS` env var to configure a denylist of sensitive header keys.
 
    For example, the Alibaba Cloud Function Compute platform adds [a variety of
-   headers][alibaba-headers] to each incoming request, some of which might be
-   sensitive. To have go-httpbin filter **all** of these headers in its own
-   responses, set
+   `x-fc-*` headers][alibaba-headers] to each incoming request, some of which
+   might be sensitive. To have go-httpbin filter **all** of these headers in
+   its own responses, set
 
        EXCLUDE_HEADERS="x-fc-*"
 
@@ -222,3 +222,4 @@ Compared to [ahmetb/go-httpbin][ahmet]:
 [Production considerations]: #production-considerations
 [zerolog]: https://github.com/rs/zerolog
 [DEVELOPMENT.md]: ./DEVELOPMENT.md
+[alibaba-headers]: https://www.alibabacloud.com/help/en/fc/user-guide/specification-details#section-3f8-5y1-i77

--- a/README.md
+++ b/README.md
@@ -169,10 +169,10 @@ public internet, consider tuning it appropriately:
    sensitive information, use the `-exclude-headers` CLI argument or
    `EXCLUDE_HEADERS` env var to configure a denylist of sensitive header keys.
 
-   For example, the Alibaba Cloud Function Compute platform adds [a variety of
-   `x-fc-*` headers][alibaba-headers] to each incoming request, some of which
-   might be sensitive. To have go-httpbin filter **all** of these headers in
-   its own responses, set
+   For example, the Alibaba Cloud Function Compute platform adds
+   [a variety of `x-fc-*` headers][alibaba-headers] to each incoming request,
+   some of which might be sensitive. To have go-httpbin filter **all** of these
+   headers in its own responses, set:
 
        EXCLUDE_HEADERS="x-fc-*"
 


### PR DESCRIPTION
Noticed the documentation for the EXCLUDE_HEADERS functionality was not correctly formatted, and took the opportunity to clean up the docs and expand the examples.