### PR TITLE
feat: add /sse endpoint to test Server-Sent Events

### DIFF
--- a/httpbin/handlers_test.go
+++ b/httpbin/handlers_test.go
@@ -3167,7 +3167,7 @@ func TestSSE(t *testing.T) {
 	t.Run("handle cancelation during stream", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 25*time.Millisecond)
+		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 		defer cancel()
 
 		req := newTestRequest(t, "GET", "/sse?duration=900ms&delay=0&count=2").WithContext(ctx)

--- a/httpbin/handlers_test.go
+++ b/httpbin/handlers_test.go
@@ -63,6 +63,9 @@ func createApp(opts ...OptionFunc) *HTTPBin {
 			DripDelay:    0,
 			DripDuration: 100 * time.Millisecond,
 			DripNumBytes: 10,
+			SSECount:     10,
+			SSEDelay:     0,
+			SSEDuration:  100 * time.Millisecond,
 		}),
 		WithMaxBodySize(maxBodySize),
 		WithMaxDuration(maxDuration),
@@ -2957,6 +2960,246 @@ func TestHostname(t *testing.T) {
 	})
 }
 
+func TestSSE(t *testing.T) {
+	t.Parallel()
+
+	parseServerSentEvent := func(t *testing.T, buf *bufio.Reader) (serverSentEvent, error) {
+		t.Helper()
+
+		// match "event: ping" line
+		eventLine, err := buf.ReadBytes('\n')
+		if err != nil {
+			return serverSentEvent{}, err
+		}
+		_, eventType, _ := bytes.Cut(eventLine, []byte(":"))
+		assert.Equal(t, string(bytes.TrimSpace(eventType)), "ping", "unexpected event type")
+
+		// match "data: {...}" line
+		dataLine, err := buf.ReadBytes('\n')
+		if err != nil {
+			return serverSentEvent{}, err
+		}
+		_, data, _ := bytes.Cut(dataLine, []byte(":"))
+		var event serverSentEvent
+		assert.NilError(t, json.Unmarshal(data, &event))
+
+		// match newline after event data
+		b, err := buf.ReadByte()
+		if err != nil && err != io.EOF {
+			assert.NilError(t, err)
+		}
+		if b != '\n' {
+			t.Fatalf("expected newline after event data, got %q", b)
+		}
+
+		return event, nil
+	}
+
+	parseServerSentEventStream := func(t *testing.T, resp *http.Response) []serverSentEvent {
+		t.Helper()
+		buf := bufio.NewReader(resp.Body)
+		var events []serverSentEvent
+		for {
+			event, err := parseServerSentEvent(t, buf)
+			if err == io.EOF {
+				break
+			}
+			assert.NilError(t, err)
+			events = append(events, event)
+		}
+		return events
+	}
+
+	okTests := []struct {
+		params   *url.Values
+		duration time.Duration
+		count    int
+	}{
+		// there are useful defaults for all values
+		{&url.Values{}, 0, 10},
+
+		// go-style durations are accepted
+		{&url.Values{"duration": {"5ms"}}, 5 * time.Millisecond, 10},
+		{&url.Values{"duration": {"10ns"}}, 0, 10},
+		{&url.Values{"delay": {"5ms"}}, 5 * time.Millisecond, 10},
+		{&url.Values{"delay": {"0h"}}, 0, 10},
+
+		// or floating point seconds
+		{&url.Values{"duration": {"0.25"}}, 250 * time.Millisecond, 10},
+		{&url.Values{"duration": {"1"}}, 1 * time.Second, 10},
+		{&url.Values{"delay": {"0.25"}}, 250 * time.Millisecond, 10},
+		{&url.Values{"delay": {"0"}}, 0, 10},
+
+		{&url.Values{"count": {"1"}}, 0, 1},
+		{&url.Values{"count": {"011"}}, 0, 11},
+		{&url.Values{"count": {fmt.Sprintf("%d", app.maxSSECount)}}, 0, int(app.maxSSECount)},
+
+		{&url.Values{"duration": {"250ms"}, "delay": {"250ms"}}, 500 * time.Millisecond, 10},
+		{&url.Values{"duration": {"250ms"}, "delay": {"0.25s"}}, 500 * time.Millisecond, 10},
+	}
+	for _, test := range okTests {
+		test := test
+		t.Run(fmt.Sprintf("ok/%s", test.params.Encode()), func(t *testing.T) {
+			t.Parallel()
+
+			url := "/sse?" + test.params.Encode()
+
+			start := time.Now()
+			req := newTestRequest(t, "GET", url)
+			resp := must.DoReq(t, client, req)
+			assert.StatusCode(t, resp, http.StatusOK)
+			events := parseServerSentEventStream(t, resp)
+
+			if elapsed := time.Since(start); elapsed < test.duration {
+				t.Fatalf("expected minimum duration of %s, request took %s", test.duration, elapsed)
+			}
+			assert.ContentType(t, resp, sseContentType)
+			assert.DeepEqual(t, resp.TransferEncoding, []string{"chunked"}, "unexpected Transfer-Encoding header")
+			assert.Equal(t, len(events), test.count, "unexpected number of events")
+		})
+	}
+
+	badTests := []struct {
+		params *url.Values
+		code   int
+	}{
+		{&url.Values{"duration": {"0"}}, http.StatusBadRequest},
+		{&url.Values{"duration": {"0s"}}, http.StatusBadRequest},
+		{&url.Values{"duration": {"1m"}}, http.StatusBadRequest},
+		{&url.Values{"duration": {"-1ms"}}, http.StatusBadRequest},
+		{&url.Values{"duration": {"1001"}}, http.StatusBadRequest},
+		{&url.Values{"duration": {"-1"}}, http.StatusBadRequest},
+		{&url.Values{"duration": {"foo"}}, http.StatusBadRequest},
+
+		{&url.Values{"delay": {"1m"}}, http.StatusBadRequest},
+		{&url.Values{"delay": {"-1ms"}}, http.StatusBadRequest},
+		{&url.Values{"delay": {"1001"}}, http.StatusBadRequest},
+		{&url.Values{"delay": {"-1"}}, http.StatusBadRequest},
+		{&url.Values{"delay": {"foo"}}, http.StatusBadRequest},
+
+		{&url.Values{"count": {"foo"}}, http.StatusBadRequest},
+		{&url.Values{"count": {"0"}}, http.StatusBadRequest},
+		{&url.Values{"count": {"-1"}}, http.StatusBadRequest},
+		{&url.Values{"count": {"0xff"}}, http.StatusBadRequest},
+		{&url.Values{"count": {fmt.Sprintf("%d", app.maxSSECount+1)}}, http.StatusBadRequest},
+
+		// request would take too long
+		{&url.Values{"duration": {"750ms"}, "delay": {"500ms"}}, http.StatusBadRequest},
+	}
+	for _, test := range badTests {
+		test := test
+		t.Run(fmt.Sprintf("bad/%s", test.params.Encode()), func(t *testing.T) {
+			t.Parallel()
+			url := "/sse?" + test.params.Encode()
+			req := newTestRequest(t, "GET", url)
+			resp := must.DoReq(t, client, req)
+			defer consumeAndCloseBody(resp)
+			assert.StatusCode(t, resp, test.code)
+		})
+	}
+
+	t.Run("writes are actually incremmental", func(t *testing.T) {
+		t.Parallel()
+
+		var (
+			duration = 100 * time.Millisecond
+			count    = 3
+			endpoint = fmt.Sprintf("/sse?duration=%s&count=%d", duration, count)
+
+			// Match server logic for calculating the delay between writes
+			wantPauseBetweenWrites = duration / time.Duration(count-1)
+		)
+
+		req := newTestRequest(t, "GET", endpoint)
+		resp := must.DoReq(t, client, req)
+		buf := bufio.NewReader(resp.Body)
+		eventCount := 0
+
+		// Here we read from the response one byte at a time, and ensure that
+		// at least the expected delay occurs for each read.
+		//
+		// The request above includes an initial delay equal to the expected
+		// wait between writes so that even the first iteration of this loop
+		// expects to wait the same amount of time for a read.
+		for i := 0; ; i++ {
+			start := time.Now()
+			event, err := parseServerSentEvent(t, buf)
+			if err == io.EOF {
+				break
+			}
+			assert.NilError(t, err)
+			gotPause := time.Since(start)
+
+			// We expect to read exactly one byte on each iteration. On the
+			// last iteration, we expct to hit EOF after reading the final
+			// byte, because the server does not pause after the last write.
+			assert.Equal(t, event.ID, i, "unexpected SSE event ID")
+
+			// only ensure that we pause for the expected time between writes
+			// (allowing for minor mismatch in local timers and server timers)
+			// after the first byte.
+			if i > 0 {
+				assert.RoughDuration(t, gotPause, wantPauseBetweenWrites, 3*time.Millisecond)
+			}
+
+			eventCount++
+		}
+
+		assert.Equal(t, eventCount, count, "unexpected number of events")
+	})
+
+	t.Run("handle cancelation during initial delay", func(t *testing.T) {
+		t.Parallel()
+
+		// For this test, we expect the client to time out and cancel the
+		// request after 10ms.  The handler should still be in its intitial
+		// delay period, so this will result in a request error since no status
+		// code will be written before the cancelation.
+		ctx, cancel := context.WithTimeout(context.Background(), 25*time.Millisecond)
+		defer cancel()
+
+		req := newTestRequest(t, "GET", "/sse?duration=500ms&delay=500ms").WithContext(ctx)
+		if _, err := client.Do(req); !os.IsTimeout(err) {
+			t.Fatalf("expected timeout error, got %s", err)
+		}
+	})
+
+	t.Run("handle cancelation during stream", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, cancel := context.WithTimeout(context.Background(), 25*time.Millisecond)
+		defer cancel()
+
+		req := newTestRequest(t, "GET", "/sse?duration=900ms&delay=0&count=2").WithContext(ctx)
+		resp := must.DoReq(t, client, req)
+		defer consumeAndCloseBody(resp)
+
+		// In this test, the server should have started an OK response before
+		// our client timeout cancels the request, so we should get an OK here.
+		assert.StatusCode(t, resp, http.StatusOK)
+
+		// But, we should time out while trying to read the whole response
+		// body.
+		body, err := io.ReadAll(resp.Body)
+		if !os.IsTimeout(err) {
+			t.Fatalf("expected timeout reading body, got %s", err)
+		}
+
+		// partial read should include the first whole event
+		event, err := parseServerSentEvent(t, bufio.NewReader(bytes.NewReader(body)))
+		assert.NilError(t, err)
+		assert.Equal(t, event.ID, 0, "unexpected SSE event ID")
+	})
+
+	t.Run("ensure HEAD request works with streaming responses", func(t *testing.T) {
+		t.Parallel()
+		req := newTestRequest(t, "HEAD", "/sse?duration=900ms&delay=100ms")
+		resp := must.DoReq(t, client, req)
+		assert.StatusCode(t, resp, http.StatusOK)
+		assert.BodySize(t, resp, 0)
+	})
+}
+
 func TestWebSocketEcho(t *testing.T) {
 	// ========================================================================
 	// Note: Here we only test input validation for the websocket endpoint.
@@ -3028,6 +3271,7 @@ func TestWebSocketEcho(t *testing.T) {
 		})
 	}
 }
+
 func newTestServer(handler http.Handler) (*httptest.Server, *http.Client) {
 	srv := httptest.NewServer(handler)
 	client := srv.Client()

--- a/httpbin/httpbin.go
+++ b/httpbin/httpbin.go
@@ -1,6 +1,7 @@
 package httpbin
 
 import (
+	"bytes"
 	"net/http"
 	"time"
 )
@@ -14,9 +15,15 @@ const (
 
 // DefaultParams defines default parameter values
 type DefaultParams struct {
+	// for the /drip endpoint
 	DripDuration time.Duration
 	DripDelay    time.Duration
 	DripNumBytes int64
+
+	// for the /sse endpoint
+	SSECount    int
+	SSEDuration time.Duration
+	SSEDelay    time.Duration
 }
 
 // DefaultDefaultParams defines the DefaultParams that are used by default. In
@@ -25,13 +32,16 @@ var DefaultDefaultParams = DefaultParams{
 	DripDuration: 2 * time.Second,
 	DripDelay:    2 * time.Second,
 	DripNumBytes: 10,
+	SSECount:     10,
+	SSEDuration:  5 * time.Second,
+	SSEDelay:     0,
 }
 
 type headersProcessorFunc func(h http.Header) http.Header
 
 // HTTPBin contains the business logic
 type HTTPBin struct {
-	// Max size of an incoming request generated response body, in bytes
+	// Max size of an incoming request or generated response body, in bytes
 	MaxBodySize int64
 
 	// Max duration of a request, for those requests that allow user control
@@ -47,6 +57,8 @@ type HTTPBin struct {
 	// Set of hosts to which the /redirect-to endpoint will allow redirects
 	AllowedRedirectDomains map[string]struct{}
 
+	// Pre-computed error message for the /redirect-to endpoint, based on
+	// -allowed-redirect-domains/ALLOWED_REDIRECT_DOMAINS
 	forbiddenRedirectError string
 
 	// The hostname to expose via /hostname.
@@ -55,14 +67,23 @@ type HTTPBin struct {
 	// The app's http handler
 	handler http.Handler
 
+	// Optional prefix under which the app will be served
 	prefix string
 
+	// Pre-rendered templates
 	indexHTML     []byte
 	formsPostHTML []byte
 
+	// Pre-computed map of special cases for the /status endpoint
 	statusSpecialCases map[int]*statusCase
 
+	// Optional function to control which headers are excluded from the
+	// /headers response
 	excludeHeadersProcessor headersProcessorFunc
+
+	// Max number of SSE events to send, based on rough estimate of single
+	// event's size
+	maxSSECount int64
 }
 
 // New creates a new HTTPBin instance
@@ -76,13 +97,19 @@ func New(opts ...OptionFunc) *HTTPBin {
 	for _, opt := range opts {
 		opt(h)
 	}
-	h.handler = h.Handler()
 
+	// pre-compute some configuration values and pre-render templates
 	h.statusSpecialCases = createSpecialCases(h.prefix)
+	h.indexHTML = h.mustRenderTemplate("index.html.tmpl")
+	h.formsPostHTML = h.mustRenderTemplate("forms-post.html.tmpl")
 
-	h.indexHTML = h.staticTemplateAssert("index.html.tmpl")
-	h.formsPostHTML = h.staticTemplateAssert("forms-post.html.tmpl")
+	// compute max Server-Sent Event count based on max request size and rough
+	// estimate of a single event's size on the wire
+	var buf bytes.Buffer
+	writeServerSentEvent(&buf, 999, time.Now())
+	h.maxSSECount = h.MaxBodySize / int64(buf.Len())
 
+	h.handler = h.Handler()
 	return h
 }
 
@@ -97,76 +124,59 @@ var _ http.Handler = &HTTPBin{}
 // Handler returns an http.Handler that exposes all HTTPBin endpoints
 func (h *HTTPBin) Handler() http.Handler {
 	mux := http.NewServeMux()
-
 	mux.HandleFunc("/", methods(h.Index, "GET"))
-	mux.HandleFunc("/forms/post", methods(h.FormsPost, "GET"))
-	mux.HandleFunc("/encoding/utf8", methods(h.UTF8, "GET"))
-
+	mux.HandleFunc("/absolute-redirect/", h.AbsoluteRedirect)
+	mux.HandleFunc("/anything", h.Anything)
+	mux.HandleFunc("/anything/", h.Anything)
+	mux.HandleFunc("/base64/", h.Base64)
+	mux.HandleFunc("/basic-auth/", h.BasicAuth)
+	mux.HandleFunc("/bearer", h.Bearer)
+	mux.HandleFunc("/bytes/", h.Bytes)
+	mux.HandleFunc("/cache", h.Cache)
+	mux.HandleFunc("/cache/", h.CacheControl)
+	mux.HandleFunc("/cookies", h.Cookies)
+	mux.HandleFunc("/cookies/delete", h.DeleteCookies)
+	mux.HandleFunc("/cookies/set", h.SetCookies)
+	mux.HandleFunc("/deflate", h.Deflate)
+	mux.HandleFunc("/delay/", h.Delay)
 	mux.HandleFunc("/delete", methods(h.RequestWithBody, "DELETE"))
+	mux.HandleFunc("/deny", h.Deny)
+	mux.HandleFunc("/digest-auth/", h.DigestAuth)
+	mux.HandleFunc("/drip", h.Drip)
+	mux.HandleFunc("/dump/request", h.DumpRequest)
+	mux.HandleFunc("/encoding/utf8", methods(h.UTF8, "GET"))
+	mux.HandleFunc("/etag/", h.ETag)
+	mux.HandleFunc("/forms/post", methods(h.FormsPost, "GET"))
 	mux.HandleFunc("/get", methods(h.Get, "GET"))
+	mux.HandleFunc("/gzip", h.Gzip)
 	mux.HandleFunc("/head", methods(h.Get, "HEAD"))
+	mux.HandleFunc("/headers", h.Headers)
+	mux.HandleFunc("/hidden-basic-auth/", h.HiddenBasicAuth)
+	mux.HandleFunc("/hostname", h.Hostname)
+	mux.HandleFunc("/html", h.HTML)
+	mux.HandleFunc("/image", h.ImageAccept)
+	mux.HandleFunc("/image/", h.Image)
+	mux.HandleFunc("/ip", h.IP)
+	mux.HandleFunc("/json", h.JSON)
+	mux.HandleFunc("/links/", h.Links)
 	mux.HandleFunc("/patch", methods(h.RequestWithBody, "PATCH"))
 	mux.HandleFunc("/post", methods(h.RequestWithBody, "POST"))
 	mux.HandleFunc("/put", methods(h.RequestWithBody, "PUT"))
-
-	mux.HandleFunc("/anything", h.Anything)
-	mux.HandleFunc("/anything/", h.Anything)
-
-	mux.HandleFunc("/ip", h.IP)
-	mux.HandleFunc("/user-agent", h.UserAgent)
-	mux.HandleFunc("/headers", h.Headers)
-	mux.HandleFunc("/response-headers", h.ResponseHeaders)
-	mux.HandleFunc("/hostname", h.Hostname)
-
-	mux.HandleFunc("/status/", h.Status)
-	mux.HandleFunc("/unstable", h.Unstable)
-
+	mux.HandleFunc("/range/", h.Range)
+	mux.HandleFunc("/redirect-to", h.RedirectTo)
 	mux.HandleFunc("/redirect/", h.Redirect)
 	mux.HandleFunc("/relative-redirect/", h.RelativeRedirect)
-	mux.HandleFunc("/absolute-redirect/", h.AbsoluteRedirect)
-	mux.HandleFunc("/redirect-to", h.RedirectTo)
-
-	mux.HandleFunc("/cookies", h.Cookies)
-	mux.HandleFunc("/cookies/set", h.SetCookies)
-	mux.HandleFunc("/cookies/delete", h.DeleteCookies)
-
-	mux.HandleFunc("/basic-auth/", h.BasicAuth)
-	mux.HandleFunc("/hidden-basic-auth/", h.HiddenBasicAuth)
-	mux.HandleFunc("/digest-auth/", h.DigestAuth)
-	mux.HandleFunc("/bearer", h.Bearer)
-
-	mux.HandleFunc("/deflate", h.Deflate)
-	mux.HandleFunc("/gzip", h.Gzip)
-
-	mux.HandleFunc("/stream/", h.Stream)
-	mux.HandleFunc("/delay/", h.Delay)
-	mux.HandleFunc("/drip", h.Drip)
-
-	mux.HandleFunc("/range/", h.Range)
-	mux.HandleFunc("/bytes/", h.Bytes)
-	mux.HandleFunc("/stream-bytes/", h.StreamBytes)
-
-	mux.HandleFunc("/html", h.HTML)
+	mux.HandleFunc("/response-headers", h.ResponseHeaders)
 	mux.HandleFunc("/robots.txt", h.Robots)
-	mux.HandleFunc("/deny", h.Deny)
-
-	mux.HandleFunc("/cache", h.Cache)
-	mux.HandleFunc("/cache/", h.CacheControl)
-	mux.HandleFunc("/etag/", h.ETag)
-
-	mux.HandleFunc("/links/", h.Links)
-
-	mux.HandleFunc("/image", h.ImageAccept)
-	mux.HandleFunc("/image/", h.Image)
-	mux.HandleFunc("/xml", h.XML)
-	mux.HandleFunc("/json", h.JSON)
-
+	mux.HandleFunc("/sse", h.SSE)
+	mux.HandleFunc("/status/", h.Status)
+	mux.HandleFunc("/stream-bytes/", h.StreamBytes)
+	mux.HandleFunc("/stream/", h.Stream)
+	mux.HandleFunc("/unstable", h.Unstable)
+	mux.HandleFunc("/user-agent", h.UserAgent)
 	mux.HandleFunc("/uuid", h.UUID)
-	mux.HandleFunc("/base64/", h.Base64)
-
-	mux.HandleFunc("/dump/request", h.DumpRequest)
-
 	mux.HandleFunc("/websocket/echo", h.WebSocketEcho)
+	mux.HandleFunc("/xml", h.XML)
 
 	// existing httpbin endpoints that we do not support
 	mux.HandleFunc("/brotli", notImplementedHandler)
@@ -176,16 +186,16 @@ func (h *HTTPBin) Handler() http.Handler {
 	// info: https://golang.org/pkg/net/http/#ServeMux
 	mux.HandleFunc("/absolute-redirect", http.NotFound)
 	mux.HandleFunc("/basic-auth", http.NotFound)
+	mux.HandleFunc("/bytes", http.NotFound)
 	mux.HandleFunc("/delay", http.NotFound)
 	mux.HandleFunc("/digest-auth", http.NotFound)
 	mux.HandleFunc("/hidden-basic-auth", http.NotFound)
+	mux.HandleFunc("/links", http.NotFound)
 	mux.HandleFunc("/redirect", http.NotFound)
 	mux.HandleFunc("/relative-redirect", http.NotFound)
 	mux.HandleFunc("/status", http.NotFound)
-	mux.HandleFunc("/stream", http.NotFound)
-	mux.HandleFunc("/bytes", http.NotFound)
 	mux.HandleFunc("/stream-bytes", http.NotFound)
-	mux.HandleFunc("/links", http.NotFound)
+	mux.HandleFunc("/stream", http.NotFound)
 
 	// Apply global middleware
 	var handler http.Handler

--- a/httpbin/responses.go
+++ b/httpbin/responses.go
@@ -9,6 +9,7 @@ const (
 	binaryContentType = "application/octet-stream"
 	htmlContentType   = "text/html; charset=utf-8"
 	jsonContentType   = "application/json; charset=utf-8"
+	sseContentType    = "text/event-stream; charset=utf-8"
 	textContentType   = "text/plain; charset=utf-8"
 )
 
@@ -86,4 +87,9 @@ type errorRespnose struct {
 	StatusCode int    `json:"status_code"`
 	Error      string `json:"error"`
 	Detail     string `json:"detail,omitempty"`
+}
+
+type serverSentEvent struct {
+	ID        int   `json:"id"`
+	Timestamp int64 `json:"timestamp"`
 }

--- a/httpbin/static/index.html.tmpl
+++ b/httpbin/static/index.html.tmpl
@@ -109,6 +109,7 @@
 <li><a href="{{.Prefix}}/relative-redirect/6"><code>{{.Prefix}}/relative-redirect/:n</code></a> 302 Relative redirects <em>n</em> times.</li>
 <li><a href="{{.Prefix}}/response-headers?Server=httpbin&amp;Content-Type=text%2Fplain%3B+charset%3DUTF-8"><code>{{.Prefix}}/response-headers?key=val</code></a> Returns given response headers.</li>
 <li><a href="{{.Prefix}}/robots.txt"><code>{{.Prefix}}/robots.txt</code></a> Returns some robots.txt rules.</li>
+<li><a href="{{.Prefix}}/sse?delay=1s&amp;duration=5s&count=10"><code>{{.Prefix}}/sse?delay=1s&amp;duration=5s&count=10</code></a> a stream of server-sent events.</li>
 <li><a href="{{.Prefix}}/status/418"><code>{{.Prefix}}/status/:code</code></a> Returns given HTTP Status code.</li>
 <li><a href="{{.Prefix}}/stream-bytes/1024"><code>{{.Prefix}}/stream-bytes/:n</code></a> Streams <em>n</em> random bytes of binary data, accepts optional <em>seed</em> and <em>chunk_size</em> integer parameters.</li>
 <li><a href="{{.Prefix}}/stream/20"><code>{{.Prefix}}/stream/:n</code></a> Streams <em>min(n, 100)</em> lines.</li>

--- a/httpbin/static_assets.go
+++ b/httpbin/static_assets.go
@@ -10,14 +10,9 @@ import (
 //go:embed static/*
 var staticAssets embed.FS
 
-// return full name of static assert
-func staticName(name string) string {
-	return path.Join("static", name)
-}
-
 // staticAsset loads an embedded static asset by name.
 func staticAsset(name string) ([]byte, error) {
-	return staticAssets.ReadFile(staticName(name))
+	return staticAssets.ReadFile(path.Join("static", name))
 }
 
 // mustStaticAsset loads an embedded static asset by name, panicking on error.
@@ -29,22 +24,15 @@ func mustStaticAsset(name string) []byte {
 	return b
 }
 
-func (h *HTTPBin) staticTemplateAssert(name string) []byte {
-	t, err := template.ParseFS(staticAssets, staticName(name))
+func (h *HTTPBin) mustRenderTemplate(name string) []byte {
+	t, err := template.New(name).Parse(string(mustStaticAsset(name)))
 	if err != nil {
 		panic(err)
 	}
-
 	var buf bytes.Buffer
-
-	d := &struct {
-		Prefix string
-	}{h.prefix}
-
-	err = t.Execute(&buf, d)
-	if err != nil {
+	ctx := struct{ Prefix string }{Prefix: h.prefix}
+	if err := t.Execute(&buf, ctx); err != nil {
 		panic(err)
 	}
-
 	return buf.Bytes()
 }


### PR DESCRIPTION
Each event is a "ping" that includes an incrementing integer ID and an integer Unix timestamp with millisecond resolution:

    event: ping
    data: {"id":9,"timestamp":1702417925258}

Fixes #150.