### PR TITLE
fix: websocket conns do not require `Connection: upgrade` header

### DIFF
--- a/httpbin/websocket/websocket.go
+++ b/httpbin/websocket/websocket.go
@@ -115,9 +115,6 @@ func (s *WebSocket) Handshake() error {
 		panic("websocket: handshake already completed")
 	}
 
-	if strings.ToLower(s.r.Header.Get("Connection")) != "upgrade" {
-		return fmt.Errorf("missing required `Connection: upgrade` header")
-	}
 	if strings.ToLower(s.r.Header.Get("Upgrade")) != "websocket" {
 		return fmt.Errorf("missing required `Upgrade: websocket` header")
 	}

--- a/httpbin/websocket/websocket_test.go
+++ b/httpbin/websocket/websocket_test.go
@@ -51,22 +51,22 @@ func TestHandshake(t *testing.T) {
 			},
 			wantStatus: http.StatusSwitchingProtocols,
 		},
-		"missing Connection header": {
+		"missing Connection header is okay": {
 			reqHeaders: map[string]string{
 				"Upgrade":               "websocket",
 				"Sec-WebSocket-Key":     "dGhlIHNhbXBsZSBub25jZQ==",
 				"Sec-WebSocket-Version": "13",
 			},
-			wantStatus: http.StatusBadRequest,
+			wantStatus: http.StatusSwitchingProtocols,
 		},
-		"incorrect Connection header": {
+		"incorrect Connection header is also okay": {
 			reqHeaders: map[string]string{
-				"Connection":            "close",
+				"Connection":            "foo",
 				"Upgrade":               "websocket",
 				"Sec-WebSocket-Key":     "dGhlIHNhbXBsZSBub25jZQ==",
 				"Sec-WebSocket-Version": "13",
 			},
-			wantStatus: http.StatusBadRequest,
+			wantStatus: http.StatusSwitchingProtocols,
 		},
 		"missing Upgrade header": {
 			reqHeaders: map[string]string{


### PR DESCRIPTION
It turns out that [the `WebSocket` API provided by browsers](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket) does not actually send the `Connection: upgrade` header that our websocket implementation (wrongly?) requires, so here we're dropping that requirement.

Tested with both https://websocketking.com/ and by pasting this ChatGPT-generated code into the Firefox web inspector's console:

```javascript
// Open a WebSocket connection
const socket = new WebSocket('ws://localhost:8080/websocket/echo');

// Event handler for when the connection is established
socket.addEventListener('open', (event) => {
  console.log('WebSocket connection opened:', event);

  // Send test messages
  const testMessages = ['Hello, server!', 'How are you?', 'Testing WebSocket'];
  testMessages.forEach((message, index) => {
    setTimeout(() => {
      console.log('Sending message:', message);
      socket.send(message);
    }, index * 1000); // Delay messages by 1 second intervals
  });
});

// Event handler for receiving messages
socket.addEventListener('message', (event) => {
  console.log('Received message:', event.data);
});

// Event handler for errors
socket.addEventListener('error', (event) => {
  console.error('WebSocket error:', event);
});

// Event handler for when the connection is closed
socket.addEventListener('close', (event) => {
  console.log('WebSocket connection closed:', event);
});
```