### PR TITLE
feat: /status endpoint supports weighted choice

### DIFF
--- a/internal/testing/assert/assert.go
+++ b/internal/testing/assert/assert.go
@@ -48,6 +48,11 @@ func NilError(t *testing.T, err error) {
 func Error(t *testing.T, got, expected error) {
 	t.Helper()
 	if got != expected {
+		if got != nil && expected != nil {
+			if got.Error() == expected.Error() {
+				return
+			}
+		}
 		t.Fatalf("expected error %v, got %v", expected, got)
 	}
 }
@@ -87,7 +92,7 @@ func ContentType(t *testing.T, resp *http.Response, contentType string) {
 	Header(t, resp, "Content-Type", contentType)
 }
 
-// expects needle in s
+// Contains asserts that needle is found in the given string.
 func Contains(t *testing.T, s string, needle string, description string) {
 	t.Helper()
 	if !strings.Contains(s, needle) {
@@ -129,4 +134,12 @@ func DurationRange(t *testing.T, got, min, max time.Duration) {
 func RoughDuration(t *testing.T, got, want time.Duration, tolerance time.Duration) {
 	t.Helper()
 	DurationRange(t, got, want-tolerance, want+tolerance)
+}
+
+// RoughlyEqual asserts that a float64 is within a certain tolerance.
+func RoughlyEqual(t *testing.T, got, want float64, epsilon float64) {
+	t.Helper()
+	if got < want-epsilon || got > want+epsilon {
+		t.Fatalf("expected value between %f and %f, got %f", want-epsilon, want+epsilon, got)
+	}
 }


### PR DESCRIPTION
Fixes compatibility with the original httpbin by making the `/status` endpoint accept multiple, optionally weighted status codes to choose from.  Per the description in #145, this implementation attempts to match original httpbin's behavior:
- If not specified, weight is 1
- If specified, weights are parsed as floats, but there is no requirement that they sum to 1.0 or are otherwise limited to any particular range

Fixes #145.