### PR TITLE
feat: support Fastly and Akamai headers for client IP addr

### DIFF
--- a/httpbin/helpers.go
+++ b/httpbin/helpers.go
@@ -49,6 +49,12 @@ func getClientIP(r *http.Request) string {
 	if clientIP := r.Header.Get("CF-Connecting-IP"); clientIP != "" {
 		return clientIP
 	}
+	if clientIP := r.Header.Get("Fastly-Client-IP"); clientIP != "" {
+		return clientIP
+	}
+	if clientIP := r.Header.Get("True-Client-IP"); clientIP != "" {
+		return clientIP
+	}
 
 	// Try to pull a reasonable value from the X-Forwarded-For header, if
 	// present, by taking the first entry in a comma-separated list of IPs.

--- a/httpbin/helpers_test.go
+++ b/httpbin/helpers_test.go
@@ -247,6 +247,26 @@ func TestGetClientIP(t *testing.T) {
 			},
 			want: "9.9.9.9",
 		},
+		"custom fastly header take precedence": {
+			given: &http.Request{
+				Header: makeHeaders(map[string]string{
+					"Fastly-Client-IP": "9.9.9.9",
+					"X-Forwarded-For":  "1.1.1.1,2.2.2.2,3.3.3.3",
+				}),
+				RemoteAddr: "0.0.0.0",
+			},
+			want: "9.9.9.9",
+		},
+		"custom akamai header take precedence": {
+			given: &http.Request{
+				Header: makeHeaders(map[string]string{
+					"True-Client-IP":  "9.9.9.9",
+					"X-Forwarded-For": "1.1.1.1,2.2.2.2,3.3.3.3",
+				}),
+				RemoteAddr: "0.0.0.0",
+			},
+			want: "9.9.9.9",
+		},
 		"x-forwarded-for is parsed": {
 			given: &http.Request{
 				Header: makeHeaders(map[string]string{


### PR DESCRIPTION
Add support for Fastly and Akamai custom headres to get a reasonable value of the client ip address.