### PR TITLE
chore(ci): tweak codecov configuration

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -31,3 +31,6 @@ comment:
   layout: "header, diff, files"
   behavior: default
   require_changes: no
+
+ignore:
+- internal/testing


### PR DESCRIPTION
Just noticed that codecov is penalizing us for limited coverage of the internal testing helper packages, which don't need coverage:

<img width="1298" alt="Screenshot 2024-02-18 at 11 47 18 AM" src="https://github.com/mccutchen/go-httpbin/assets/57938/53e7cd11-4ede-4b31-af7e-f0f713d7cff2">

Hopefully this little tweak will fix that.