### PR TITLE
add appProcotol to the k8s service for port name 'http'

### DIFF
--- a/kustomize/resources.yaml
+++ b/kustomize/resources.yaml
@@ -32,3 +32,4 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
+      appProtocol: http


### PR DESCRIPTION
Add the `appProcotol` field to the k8s service for port name 'http'

This is recommended - and sometimes required - by third-party apps like Istio or Kuma

Official doc: https://kubernetes.io/docs/concepts/services-networking/service/#application-protocol
