### PR TITLE
chore(ci): fix code coverage uploads

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,6 +48,6 @@ jobs:
         with:
           go-version: 'stable'
 
-      - uses: golangci/golangci-lint-action@v3
+      - uses: golangci/golangci-lint-action@v6
         with:
           version: latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,8 +33,11 @@ jobs:
     - name: test
       run: make testci
 
-    - uses: codecov/codecov-action@v3
+    - uses: codecov/codecov-action@v4
       if: ${{ matrix.go-version == 'stable' }}
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        fail_ci_if_error: true
 
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Looks like codecov.io now requires an explicit auth token, per [this failed upload](https://github.com/mccutchen/go-httpbin/actions/runs/10856421653/job/30131034321):

> [2024-09-13T21:34:57.324Z] ['error'] There was an error running the uploader: Error uploading to [https://codecov.io:](https://codecov.io/) Error: There was an error fetching the storage URL during POST: 429 - {'detail': ErrorDetail(string='Rate limit reached. Please upload with the Codecov repository upload token to resolve issue. Expected time to availability: 1478s.', code='throttled')}
> [2024-09-13T21:34:57.324Z] ['info'] Codecov will exit with status code 0. If you are expecting a non-zero exit code, please pass in the `-Z` flag