### PR TITLE
feat: add `/trailers` endpoint

### DIFF
--- a/httpbin/httpbin.go
+++ b/httpbin/httpbin.go
@@ -181,6 +181,7 @@ func (h *HTTPBin) Handler() http.Handler {
 	mux.HandleFunc("/status/{code}", h.Status)
 	mux.HandleFunc("/stream-bytes/{numBytes}", h.StreamBytes)
 	mux.HandleFunc("/stream/{numLines}", h.Stream)
+	mux.HandleFunc("/trailers", h.Trailers)
 	mux.HandleFunc("/unstable", h.Unstable)
 	mux.HandleFunc("/user-agent", h.UserAgent)
 	mux.HandleFunc("/uuid", h.UUID)

--- a/httpbin/static/index.html.tmpl
+++ b/httpbin/static/index.html.tmpl
@@ -113,6 +113,7 @@
 <li><a href="{{.Prefix}}/status/418"><code>{{.Prefix}}/status/:code</code></a> Returns given HTTP Status code.</li>
 <li><a href="{{.Prefix}}/stream-bytes/1024"><code>{{.Prefix}}/stream-bytes/:n</code></a> Streams <em>n</em> random bytes of binary data, accepts optional <em>seed</em> and <em>chunk_size</em> integer parameters.</li>
 <li><a href="{{.Prefix}}/stream/20"><code>{{.Prefix}}/stream/:n</code></a> Streams <em>min(n, 100)</em> lines.</li>
+<li><a href="{{.Prefix}}/trailers?trailer1=value1&amp;trailer2=value2"><code>{{.Prefix}}/trailers?key=val</code></a> Returns JSON response with query params added as HTTP Trailers.</li>
 <li><a href="{{.Prefix}}/unstable"><code>{{.Prefix}}/unstable</code></a> Fails half the time, accepts optional <em>failure_rate</em> float and <em>seed</em> integer parameters.</li>
 <li><a href="{{.Prefix}}/user-agent"><code>{{.Prefix}}/user-agent</code></a> Returns user-agent.</li>
 <li><a href="{{.Prefix}}/uuid"><code>{{.Prefix}}/uuid</code></a> Generates a <a href="https://en.wikipedia.org/wiki/Universally_unique_identifier">UUIDv4</a> value.</li>


### PR DESCRIPTION
This adds a new `/trailers` endpoint which allows clients to specify trailer key/value pairs in the query parameters, similar to the existing `/cookies/set` and `/response-headers` endpoints.

Per discussion on https://github.com/mccutchen/go-httpbin/issues/72, we'll likely add more useful trailers to some of the existing endpoints as a follow-up.