### PR TITLE
refactor: minor tweaks to `/drip` implementation

### DIFF
--- a/httpbin/handlers_test.go
+++ b/httpbin/handlers_test.go
@@ -738,7 +738,7 @@ func testRequestWithBodyExpect100Continue(t *testing.T, verb, path string) {
 	})
 
 	t.Run("zero content-length ignored", func(t *testing.T) {
-		// The Go stdlib's Expect:100-continue handling requires either a a)
+		// The Go stdlib's Expect:100-continue handling requires either a)
 		// non-zero Content-Length header or b) Transfer-Encoding:chunked
 		// header to be present.  Otherwise, the Expect header is ignored and
 		// the request is processed normally.
@@ -2037,7 +2037,7 @@ func TestDrip(t *testing.T) {
 			elapsed := time.Since(start)
 
 			assert.StatusCode(t, resp, test.code)
-			assert.ContentType(t, resp, binaryContentType)
+			assert.ContentType(t, resp, textContentType)
 			assert.Header(t, resp, "Content-Length", strconv.Itoa(test.numbytes))
 			if elapsed < test.duration {
 				t.Fatalf("expected minimum duration of %s, request took %s", test.duration, elapsed)
@@ -2125,7 +2125,7 @@ func TestDrip(t *testing.T) {
 			// (allowing for minor mismatch in local timers and server timers)
 			// after the first byte.
 			if i > 0 {
-				assert.RoughDuration(t, gotPause, wantPauseBetweenWrites, 3*time.Millisecond)
+				assert.RoughlyEqual(t, gotPause, wantPauseBetweenWrites, 3*time.Millisecond)
 			}
 		}
 
@@ -3240,7 +3240,7 @@ func TestSSE(t *testing.T) {
 			// (allowing for minor mismatch in local timers and server timers)
 			// after the first byte.
 			if i > 0 {
-				assert.RoughDuration(t, gotPause, wantPauseBetweenWrites, 3*time.Millisecond)
+				assert.RoughlyEqual(t, gotPause, wantPauseBetweenWrites, 3*time.Millisecond)
 			}
 
 			eventCount++

--- a/httpbin/static/index.html.tmpl
+++ b/httpbin/static/index.html.tmpl
@@ -79,7 +79,7 @@
 <li><a href="{{.Prefix}}/deny"><code>{{.Prefix}}/deny</code></a> Denied by robots.txt file.</li>
 <li><a href="{{.Prefix}}/digest-auth/auth/user/password"><code>{{.Prefix}}/digest-auth/:qop/:user/:password</code></a> Challenges HTTP Digest Auth using default MD5 algorithm</li>
 <li><a href="{{.Prefix}}/digest-auth/auth/user/password/SHA-256"><code>{{.Prefix}}/digest-auth/:qop/:user/:password/:algorithm</code></a> Challenges HTTP Digest Auth using specified algorithm (MD5 or SHA-256)</li>
-<li><a href="{{.Prefix}}/drip?code=200&amp;numbytes=5&amp;duration=5"><code>{{.Prefix}}/drip?numbytes=n&amp;duration=s&amp;delay=s&amp;code=code</code></a> Drips data over a duration after an optional initial delay, then (optionally) returns with the given status code.</li>
+<li><a href="{{.Prefix}}/drip?code=200&amp;numbytes=5&amp;duration=5"><code>{{.Prefix}}/drip?numbytes=n&amp;duration=s&amp;delay=s&amp;code=code</code></a> Drips data over the given duration after an optional initial delay, simulating a slow HTTP server.</li>
 <li><a href="{{.Prefix}}/dump/request"><code>{{.Prefix}}/dump/request</code></a> Returns the given request in its HTTP/1.x wire approximate representation.</li>
 <li><a href="{{.Prefix}}/encoding/utf8"><code>{{.Prefix}}/encoding/utf8</code></a> Returns page containing UTF-8 data.</li>
 <li><a href="{{.Prefix}}/etag/etag"><code>{{.Prefix}}/etag/:etag</code></a> Assumes the resource has the given etag and responds to If-None-Match header with a 200 or 304 and If-Match with a 200 or 412 as appropriate.</li>

--- a/httpbin/websocket/websocket_test.go
+++ b/httpbin/websocket/websocket_test.go
@@ -281,7 +281,7 @@ func TestConnectionLimits(t *testing.T) {
 			elapsed := time.Since(start)
 
 			assert.Error(t, err, io.EOF)
-			assert.RoughDuration(t, elapsed, maxDuration, 25*time.Millisecond)
+			assert.RoughlyEqual(t, elapsed, maxDuration, 25*time.Millisecond)
 		}
 	})
 
@@ -363,11 +363,11 @@ func TestConnectionLimits(t *testing.T) {
 			conn.Close()
 
 			assert.Equal(t, os.IsTimeout(err), true, "expected timeout error")
-			assert.RoughDuration(t, elapsedClientTime, clientTimeout, 10*time.Millisecond)
+			assert.RoughlyEqual(t, elapsedClientTime, clientTimeout, 10*time.Millisecond)
 
 			// wait for the server to finish
 			wg.Wait()
-			assert.RoughDuration(t, elapsedServerTime, clientTimeout, 10*time.Millisecond)
+			assert.RoughlyEqual(t, elapsedServerTime, clientTimeout, 10*time.Millisecond)
 		}
 	})
 }

--- a/internal/testing/assert/assert.go
+++ b/internal/testing/assert/assert.go
@@ -129,17 +129,14 @@ func DurationRange(t *testing.T, got, min, max time.Duration) {
 	}
 }
 
-// RoughDuration asserts that a duration is within a certain tolerance of a
-// given value.
-func RoughDuration(t *testing.T, got, want time.Duration, tolerance time.Duration) {
-	t.Helper()
-	DurationRange(t, got, want-tolerance, want+tolerance)
+type Number interface {
+	~int64 | ~float64
 }
 
-// RoughlyEqual asserts that a float64 is within a certain tolerance.
-func RoughlyEqual(t *testing.T, got, want float64, epsilon float64) {
+// RoughlyEqual asserts that a numeric value is within a certain tolerance.
+func RoughlyEqual[T Number](t *testing.T, got, want T, epsilon T) {
 	t.Helper()
 	if got < want-epsilon || got > want+epsilon {
-		t.Fatalf("expected value between %f and %f, got %f", want-epsilon, want+epsilon, got)
+		t.Fatalf("expected value between %v and %v, got %v", want-epsilon, want+epsilon, got)
 	}
 }


### PR DESCRIPTION
A handful of drive-by tweaks to the `/drip` implementation:
- Update docs to clarify intended uses (a helpful reminder for myself, if nothing else)
- Ensure all bad requests use standard JSON error responses
- Switch from binary to text content type

This also includes a small fix to the internal testing library, dropping the `assert.RoughDuration()` helper in favor of an updated generic `assert.RoughlyEqual()` implementation that works with the `time.Duration` type.