### PR TITLE
feat: add `Server-Timing` headers/trailers where relevant

### DIFF
--- a/httpbin/helpers.go
+++ b/httpbin/helpers.go
@@ -580,29 +580,3 @@ func encodeServerTimings(timings []serverTiming) string {
 	}
 	return strings.Join(entries, ", ")
 }
-
-func decodeServerTimings(headerVal string) map[string]serverTiming {
-	if headerVal == "" {
-		return nil
-	}
-	timings := map[string]serverTiming{}
-	for _, entry := range strings.Split(headerVal, ",") {
-		var t serverTiming
-		for _, kv := range strings.Split(entry, ";") {
-			kv = strings.TrimSpace(kv)
-			key, val, _ := strings.Cut(kv, "=")
-			switch key {
-			case "dur":
-				t.dur, _ = time.ParseDuration(val + "ms")
-			case "desc":
-				t.desc = strings.Trim(val, "\"")
-			default:
-				t.name = key
-			}
-		}
-		if t.name != "" {
-			timings[t.name] = t
-		}
-	}
-	return timings
-}

--- a/httpbin/helpers_test.go
+++ b/httpbin/helpers_test.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"regexp"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -544,4 +545,30 @@ func normalizeChoices[T any](choices []weightedChoice[T]) []weightedChoice[T] {
 		normalized = append(normalized, weightedChoice[T]{Choice: wc.Choice, Weight: wc.Weight / totalWeight})
 	}
 	return normalized
+}
+
+func decodeServerTimings(headerVal string) map[string]serverTiming {
+	if headerVal == "" {
+		return nil
+	}
+	timings := map[string]serverTiming{}
+	for _, entry := range strings.Split(headerVal, ",") {
+		var t serverTiming
+		for _, kv := range strings.Split(entry, ";") {
+			kv = strings.TrimSpace(kv)
+			key, val, _ := strings.Cut(kv, "=")
+			switch key {
+			case "dur":
+				t.dur, _ = time.ParseDuration(val + "ms")
+			case "desc":
+				t.desc = strings.Trim(val, "\"")
+			default:
+				t.name = key
+			}
+		}
+		if t.name != "" {
+			timings[t.name] = t
+		}
+	}
+	return timings
 }


### PR DESCRIPTION
Here we add [Server-Timing headers/trailers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Server-Timing) to endpoints that let clients control response timing:

- `/delay` (header)
- `/drip` (header)
- `/sse` (trailer) 
 
Here's how this timing info is surfaced in the Firefox network inspector for the `/sse` endpoint:

<img width="1304" alt="Screenshot 2024-09-17 at 12 27 53 AM" src="https://github.com/user-attachments/assets/7ca38543-ad2f-4b53-bc8d-57646300ac0e">