### PR TITLE
feat: add /env endpoint to allow exposing operator-controlled info from the server

### DIFF
--- a/httpbin/cmd/cmd.go
+++ b/httpbin/cmd/cmd.go
@@ -74,10 +74,20 @@ func mainImpl(args []string, getEnv func(string) string, getHostname func() (str
 		logger = slog.New(handler)
 	}
 
+	env := make(map[string]string)
+	for _, e := range os.Environ() {
+		v := strings.SplitN(e, "=", 2)
+		if !strings.HasPrefix(v[0], "HTTPBIN_") {
+			continue
+		}
+		env[v[0]] = v[1]
+	}
+
 	opts := []httpbin.OptionFunc{
 		httpbin.WithMaxBodySize(cfg.MaxBodySize),
 		httpbin.WithMaxDuration(cfg.MaxDuration),
 		httpbin.WithObserver(httpbin.StdLogObserver(logger)),
+		httpbin.WithEnv(env),
 		httpbin.WithExcludeHeaders(cfg.ExcludeHeaders),
 	}
 	if cfg.Prefix != "" {

--- a/httpbin/cmd/cmd.go
+++ b/httpbin/cmd/cmd.go
@@ -25,6 +25,7 @@ const (
 	defaultListenHost = "0.0.0.0"
 	defaultListenPort = 8080
 	defaultLogFormat  = "text"
+	defaultEnvPrefix  = "HTTPBIN_ENV_"
 
 	// Reasonable defaults for our http server
 	srvReadTimeout       = 5 * time.Second
@@ -41,7 +42,7 @@ func Main() int {
 // mainImpl is the real implementation of Main(), extracted for better
 // testability.
 func mainImpl(args []string, getEnvVal func(string) string, getEnviron func() []string, getHostname func() (string, error), out io.Writer) int {
-	cfg, err := loadConfig(args, getEnvVal, getHostname)
+	cfg, err := loadConfig(args, getEnvVal, getEnviron, getHostname)
 	if err != nil {
 		if cfgErr, ok := err.(ConfigError); ok {
 			// for -h/-help, just print usage and exit without error
@@ -74,20 +75,11 @@ func mainImpl(args []string, getEnvVal func(string) string, getEnviron func() []
 		logger = slog.New(handler)
 	}
 
-	httpbinEnv := make(map[string]string)
-	for _, envVar := range getEnviron() {
-		name, value, _ := strings.Cut(envVar, "=")
-		if !strings.HasPrefix(name, "HTTPBIN_ENV_") {
-			continue
-		}
-		httpbinEnv[name] = value
-	}
-
 	opts := []httpbin.OptionFunc{
+		httpbin.WithEnv(cfg.Env),
 		httpbin.WithMaxBodySize(cfg.MaxBodySize),
 		httpbin.WithMaxDuration(cfg.MaxDuration),
 		httpbin.WithObserver(httpbin.StdLogObserver(logger)),
-		httpbin.WithEnv(httpbinEnv),
 		httpbin.WithExcludeHeaders(cfg.ExcludeHeaders),
 	}
 	if cfg.Prefix != "" {
@@ -120,6 +112,7 @@ func mainImpl(args []string, getEnvVal func(string) string, getEnviron func() []
 // config holds the configuration needed to initialize and run go-httpbin as a
 // standalone server.
 type config struct {
+	Env                    map[string]string
 	AllowedRedirectDomains []string
 	ListenHost             string
 	ExcludeHeaders         string
@@ -154,7 +147,7 @@ func (e ConfigError) Error() string {
 
 // loadConfig parses command line arguments and env vars into a fully resolved
 // Config struct. Command line arguments take precedence over env vars.
-func loadConfig(args []string, getEnv func(string) string, getHostname func() (string, error)) (*config, error) {
+func loadConfig(args []string, getEnvVal func(string) string, getEnviron func() []string, getHostname func() (string, error)) (*config, error) {
 	cfg := &config{}
 
 	fs := flag.NewFlagSet("go-httpbin", flag.ContinueOnError)
@@ -202,24 +195,24 @@ func loadConfig(args []string, getEnv func(string) string, getHostname func() (s
 	// Command line flags take precedence over environment vars, so we only
 	// check for environment vars if we have default values for our command
 	// line flags.
-	if cfg.MaxBodySize == httpbin.DefaultMaxBodySize && getEnv("MAX_BODY_SIZE") != "" {
-		cfg.MaxBodySize, err = strconv.ParseInt(getEnv("MAX_BODY_SIZE"), 10, 64)
+	if cfg.MaxBodySize == httpbin.DefaultMaxBodySize && getEnvVal("MAX_BODY_SIZE") != "" {
+		cfg.MaxBodySize, err = strconv.ParseInt(getEnvVal("MAX_BODY_SIZE"), 10, 64)
 		if err != nil {
-			return nil, configErr("invalid value %#v for env var MAX_BODY_SIZE: parse error", getEnv("MAX_BODY_SIZE"))
+			return nil, configErr("invalid value %#v for env var MAX_BODY_SIZE: parse error", getEnvVal("MAX_BODY_SIZE"))
 		}
 	}
 
-	if cfg.MaxDuration == httpbin.DefaultMaxDuration && getEnv("MAX_DURATION") != "" {
-		cfg.MaxDuration, err = time.ParseDuration(getEnv("MAX_DURATION"))
+	if cfg.MaxDuration == httpbin.DefaultMaxDuration && getEnvVal("MAX_DURATION") != "" {
+		cfg.MaxDuration, err = time.ParseDuration(getEnvVal("MAX_DURATION"))
 		if err != nil {
-			return nil, configErr("invalid value %#v for env var MAX_DURATION: parse error", getEnv("MAX_DURATION"))
+			return nil, configErr("invalid value %#v for env var MAX_DURATION: parse error", getEnvVal("MAX_DURATION"))
 		}
 	}
-	if cfg.ListenHost == defaultListenHost && getEnv("HOST") != "" {
-		cfg.ListenHost = getEnv("HOST")
+	if cfg.ListenHost == defaultListenHost && getEnvVal("HOST") != "" {
+		cfg.ListenHost = getEnvVal("HOST")
 	}
 	if cfg.Prefix == "" {
-		if prefix := getEnv("PREFIX"); prefix != "" {
+		if prefix := getEnvVal("PREFIX"); prefix != "" {
 			cfg.Prefix = prefix
 		}
 	}
@@ -231,29 +224,29 @@ func loadConfig(args []string, getEnv func(string) string, getHostname func() (s
 			return nil, configErr("Prefix %#v must not end with a slash", cfg.Prefix)
 		}
 	}
-	if cfg.ExcludeHeaders == "" && getEnv("EXCLUDE_HEADERS") != "" {
-		cfg.ExcludeHeaders = getEnv("EXCLUDE_HEADERS")
+	if cfg.ExcludeHeaders == "" && getEnvVal("EXCLUDE_HEADERS") != "" {
+		cfg.ExcludeHeaders = getEnvVal("EXCLUDE_HEADERS")
 	}
-	if cfg.ListenPort == defaultListenPort && getEnv("PORT") != "" {
-		cfg.ListenPort, err = strconv.Atoi(getEnv("PORT"))
+	if cfg.ListenPort == defaultListenPort && getEnvVal("PORT") != "" {
+		cfg.ListenPort, err = strconv.Atoi(getEnvVal("PORT"))
 		if err != nil {
-			return nil, configErr("invalid value %#v for env var PORT: parse error", getEnv("PORT"))
+			return nil, configErr("invalid value %#v for env var PORT: parse error", getEnvVal("PORT"))
 		}
 	}
 
-	if cfg.TLSCertFile == "" && getEnv("HTTPS_CERT_FILE") != "" {
-		cfg.TLSCertFile = getEnv("HTTPS_CERT_FILE")
+	if cfg.TLSCertFile == "" && getEnvVal("HTTPS_CERT_FILE") != "" {
+		cfg.TLSCertFile = getEnvVal("HTTPS_CERT_FILE")
 	}
-	if cfg.TLSKeyFile == "" && getEnv("HTTPS_KEY_FILE") != "" {
-		cfg.TLSKeyFile = getEnv("HTTPS_KEY_FILE")
+	if cfg.TLSKeyFile == "" && getEnvVal("HTTPS_KEY_FILE") != "" {
+		cfg.TLSKeyFile = getEnvVal("HTTPS_KEY_FILE")
 	}
 	if cfg.TLSCertFile != "" || cfg.TLSKeyFile != "" {
 		if cfg.TLSCertFile == "" || cfg.TLSKeyFile == "" {
 			return nil, configErr("https cert and key must both be provided")
 		}
 	}
-	if cfg.LogFormat == defaultLogFormat && getEnv("LOG_FORMAT") != "" {
-		cfg.LogFormat = getEnv("LOG_FORMAT")
+	if cfg.LogFormat == defaultLogFormat && getEnvVal("LOG_FORMAT") != "" {
+		cfg.LogFormat = getEnvVal("LOG_FORMAT")
 	}
 	if cfg.LogFormat != "text" && cfg.LogFormat != "json" {
 		return nil, configErr(`invalid log format %q, must be "text" or "json"`, cfg.LogFormat)
@@ -262,7 +255,7 @@ func loadConfig(args []string, getEnv func(string) string, getHostname func() (s
 	// useRealHostname will be true if either the `-use-real-hostname`
 	// arg is given on the command line or if the USE_REAL_HOSTNAME env var
 	// is one of "1" or "true".
-	if useRealHostnameEnv := getEnv("USE_REAL_HOSTNAME"); useRealHostnameEnv == "1" || useRealHostnameEnv == "true" {
+	if useRealHostnameEnv := getEnvVal("USE_REAL_HOSTNAME"); useRealHostnameEnv == "1" || useRealHostnameEnv == "true" {
 		cfg.rawUseRealHostname = true
 	}
 	if cfg.rawUseRealHostname {
@@ -273,8 +266,8 @@ func loadConfig(args []string, getEnv func(string) string, getHostname func() (s
 	}
 
 	// split comma-separated list of domains into a slice, if given
-	if cfg.rawAllowedRedirectDomains == "" && getEnv("ALLOWED_REDIRECT_DOMAINS") != "" {
-		cfg.rawAllowedRedirectDomains = getEnv("ALLOWED_REDIRECT_DOMAINS")
+	if cfg.rawAllowedRedirectDomains == "" && getEnvVal("ALLOWED_REDIRECT_DOMAINS") != "" {
+		cfg.rawAllowedRedirectDomains = getEnvVal("ALLOWED_REDIRECT_DOMAINS")
 	}
 	for _, domain := range strings.Split(cfg.rawAllowedRedirectDomains, ",") {
 		if strings.TrimSpace(domain) != "" {
@@ -285,6 +278,18 @@ func loadConfig(args []string, getEnv func(string) string, getHostname func() (s
 	// reset temporary fields to their zero values
 	cfg.rawAllowedRedirectDomains = ""
 	cfg.rawUseRealHostname = false
+
+	for _, envVar := range getEnviron() {
+		name, value, _ := strings.Cut(envVar, "=")
+		if !strings.HasPrefix(name, defaultEnvPrefix) {
+			continue
+		}
+		if cfg.Env == nil {
+			cfg.Env = make(map[string]string)
+		}
+		cfg.Env[name] = value
+	}
+
 	return cfg, nil
 }
 

--- a/httpbin/cmd/cmd.go
+++ b/httpbin/cmd/cmd.go
@@ -35,13 +35,13 @@ const (
 // Main is the main entrypoint for the go-httpbin binary. See loadConfig() for
 // command line argument parsing.
 func Main() int {
-	return mainImpl(os.Args[1:], os.Getenv, os.Hostname, os.Stderr)
+	return mainImpl(os.Args[1:], os.Getenv, os.Environ, os.Hostname, os.Stderr)
 }
 
 // mainImpl is the real implementation of Main(), extracted for better
 // testability.
-func mainImpl(args []string, getEnv func(string) string, getHostname func() (string, error), out io.Writer) int {
-	cfg, err := loadConfig(args, getEnv, getHostname)
+func mainImpl(args []string, getEnvVal func(string) string, getEnviron func() []string, getHostname func() (string, error), out io.Writer) int {
+	cfg, err := loadConfig(args, getEnvVal, getHostname)
 	if err != nil {
 		if cfgErr, ok := err.(ConfigError); ok {
 			// for -h/-help, just print usage and exit without error
@@ -75,7 +75,7 @@ func mainImpl(args []string, getEnv func(string) string, getHostname func() (str
 	}
 
 	httpbinEnv := make(map[string]string)
-	for _, envVar := range os.Environ() {
+	for _, envVar := range getEnviron() {
 		name, value, _ := strings.Cut(envVar, "=")
 		if !strings.HasPrefix(name, "HTTPBIN_ENV_") {
 			continue

--- a/httpbin/cmd/cmd.go
+++ b/httpbin/cmd/cmd.go
@@ -77,7 +77,7 @@ func mainImpl(args []string, getEnv func(string) string, getHostname func() (str
 	httpbinEnv := make(map[string]string)
 	for _, envVar := range os.Environ() {
 		name, value, _ := strings.Cut(envVar, "=")
-		if !strings.HasPrefix(name, "HTTPBIN_") {
+		if !strings.HasPrefix(name, "HTTPBIN_ENV_") {
 			continue
 		}
 		httpbinEnv[name] = value

--- a/httpbin/cmd/cmd.go
+++ b/httpbin/cmd/cmd.go
@@ -74,20 +74,20 @@ func mainImpl(args []string, getEnv func(string) string, getHostname func() (str
 		logger = slog.New(handler)
 	}
 
-	env := make(map[string]string)
-	for _, e := range os.Environ() {
-		v := strings.SplitN(e, "=", 2)
-		if !strings.HasPrefix(v[0], "HTTPBIN_") {
+	httpbinEnv := make(map[string]string)
+	for _, envVar := range os.Environ() {
+		name, value, _ := strings.Cut(envVar, "=")
+		if !strings.HasPrefix(name, "HTTPBIN_") {
 			continue
 		}
-		env[v[0]] = v[1]
+		httpbinEnv[name] = value
 	}
 
 	opts := []httpbin.OptionFunc{
 		httpbin.WithMaxBodySize(cfg.MaxBodySize),
 		httpbin.WithMaxDuration(cfg.MaxDuration),
 		httpbin.WithObserver(httpbin.StdLogObserver(logger)),
-		httpbin.WithEnv(env),
+		httpbin.WithEnv(httpbinEnv),
 		httpbin.WithExcludeHeaders(cfg.ExcludeHeaders),
 	}
 	if cfg.Prefix != "" {

--- a/httpbin/cmd/cmd_test.go
+++ b/httpbin/cmd/cmd_test.go
@@ -540,8 +540,9 @@ func TestMainImpl(t *testing.T) {
 
 	testCases := map[string]struct {
 		args        []string
-		env         map[string]string
+		optionsEnv  map[string]string
 		getHostname func() (string, error)
+		env         []string
 		wantCode    int
 		wantOut     string
 		wantOutFn   func(t *testing.T, out string)
@@ -606,7 +607,7 @@ func TestMainImpl(t *testing.T) {
 			}
 
 			buf := &bytes.Buffer{}
-			gotCode := mainImpl(tc.args, func(key string) string { return tc.env[key] }, tc.getHostname, buf)
+			gotCode := mainImpl(tc.args, func(key string) string { return tc.optionsEnv[key] }, func() []string { return tc.env }, tc.getHostname, buf)
 			out := buf.String()
 
 			if gotCode != tc.wantCode {

--- a/httpbin/cmd/cmd_test.go
+++ b/httpbin/cmd/cmd_test.go
@@ -53,9 +53,8 @@ func TestLoadConfig(t *testing.T) {
 
 	testCases := map[string]struct {
 		args        []string
-		optionsEnv  map[string]string
+		env         map[string]string
 		getHostname func() (string, error)
-		env         []string
 		wantCfg     *config
 		wantErr     error
 		wantOut     string
@@ -84,8 +83,8 @@ func TestLoadConfig(t *testing.T) {
 			wantErr: errors.New("invalid value \"foo\" for flag -max-body-size: parse error"),
 		},
 		"invalid MAX_BODY_SIZE": {
-			optionsEnv: map[string]string{"MAX_BODY_SIZE": "foo"},
-			wantErr:    errors.New("invalid value \"foo\" for env var MAX_BODY_SIZE: parse error"),
+			env:     map[string]string{"MAX_BODY_SIZE": "foo"},
+			wantErr: errors.New("invalid value \"foo\" for env var MAX_BODY_SIZE: parse error"),
 		},
 		"ok -max-body-size": {
 			args: []string{"-max-body-size", "99"},
@@ -98,7 +97,7 @@ func TestLoadConfig(t *testing.T) {
 			},
 		},
 		"ok MAX_BODY_SIZE": {
-			optionsEnv: map[string]string{"MAX_BODY_SIZE": "9999"},
+			env: map[string]string{"MAX_BODY_SIZE": "9999"},
 			wantCfg: &config{
 				ListenHost:  "0.0.0.0",
 				ListenPort:  8080,
@@ -108,8 +107,8 @@ func TestLoadConfig(t *testing.T) {
 			},
 		},
 		"ok max body size CLI takes precedence over env": {
-			args:       []string{"-max-body-size", "1234"},
-			optionsEnv: map[string]string{"MAX_BODY_SIZE": "5678"},
+			args: []string{"-max-body-size", "1234"},
+			env:  map[string]string{"MAX_BODY_SIZE": "5678"},
 			wantCfg: &config{
 				ListenHost:  "0.0.0.0",
 				ListenPort:  8080,
@@ -125,8 +124,8 @@ func TestLoadConfig(t *testing.T) {
 			wantErr: errors.New("invalid value \"foo\" for flag -max-duration: parse error"),
 		},
 		"invalid MAX_DURATION": {
-			optionsEnv: map[string]string{"MAX_DURATION": "foo"},
-			wantErr:    errors.New("invalid value \"foo\" for env var MAX_DURATION: parse error"),
+			env:     map[string]string{"MAX_DURATION": "foo"},
+			wantErr: errors.New("invalid value \"foo\" for env var MAX_DURATION: parse error"),
 		},
 		"ok -max-duration": {
 			args: []string{"-max-duration", "99s"},
@@ -139,7 +138,7 @@ func TestLoadConfig(t *testing.T) {
 			},
 		},
 		"ok MAX_DURATION": {
-			optionsEnv: map[string]string{"MAX_DURATION": "9999s"},
+			env: map[string]string{"MAX_DURATION": "9999s"},
 			wantCfg: &config{
 				ListenHost:  "0.0.0.0",
 				ListenPort:  8080,
@@ -149,8 +148,8 @@ func TestLoadConfig(t *testing.T) {
 			},
 		},
 		"ok max duration size CLI takes precedence over env": {
-			args:       []string{"-max-duration", "1234s"},
-			optionsEnv: map[string]string{"MAX_DURATION": "5678s"},
+			args: []string{"-max-duration", "1234s"},
+			env:  map[string]string{"MAX_DURATION": "5678s"},
 			wantCfg: &config{
 				ListenHost:  "0.0.0.0",
 				ListenPort:  8080,
@@ -172,7 +171,7 @@ func TestLoadConfig(t *testing.T) {
 			},
 		},
 		"ok HOST": {
-			optionsEnv: map[string]string{"HOST": "192.0.0.2"},
+			env: map[string]string{"HOST": "192.0.0.2"},
 			wantCfg: &config{
 				ListenHost:  "192.0.0.2",
 				ListenPort:  8080,
@@ -182,8 +181,8 @@ func TestLoadConfig(t *testing.T) {
 			},
 		},
 		"ok host cli takes precedence over end": {
-			args:       []string{"-host", "99.99.99.99"},
-			optionsEnv: map[string]string{"HOST": "11.11.11.11"},
+			args: []string{"-host", "99.99.99.99"},
+			env:  map[string]string{"HOST": "11.11.11.11"},
 			wantCfg: &config{
 				ListenHost:  "99.99.99.99",
 				ListenPort:  8080,
@@ -199,8 +198,8 @@ func TestLoadConfig(t *testing.T) {
 			wantErr: errors.New("invalid value \"foo\" for flag -port: parse error"),
 		},
 		"invalid PORT": {
-			optionsEnv: map[string]string{"PORT": "foo"},
-			wantErr:    errors.New("invalid value \"foo\" for env var PORT: parse error"),
+			env:     map[string]string{"PORT": "foo"},
+			wantErr: errors.New("invalid value \"foo\" for env var PORT: parse error"),
 		},
 		"ok -port": {
 			args: []string{"-port", "99"},
@@ -213,7 +212,7 @@ func TestLoadConfig(t *testing.T) {
 			},
 		},
 		"ok PORT": {
-			optionsEnv: map[string]string{"PORT": "9999"},
+			env: map[string]string{"PORT": "9999"},
 			wantCfg: &config{
 				ListenHost:  defaultListenHost,
 				ListenPort:  9999,
@@ -223,8 +222,8 @@ func TestLoadConfig(t *testing.T) {
 			},
 		},
 		"ok port CLI takes precedence over env": {
-			args:       []string{"-port", "1234"},
-			optionsEnv: map[string]string{"PORT": "5678"},
+			args: []string{"-port", "1234"},
+			env:  map[string]string{"PORT": "5678"},
 			wantCfg: &config{
 				ListenHost:  defaultListenHost,
 				ListenPort:  1234,
@@ -244,8 +243,8 @@ func TestLoadConfig(t *testing.T) {
 			wantErr: errors.New("Prefix \"/invalidprefix2/\" must not end with a slash"),
 		},
 		"ok -prefix takes precedence over env": {
-			args:       []string{"-prefix", "/prefix1"},
-			optionsEnv: map[string]string{"PREFIX": "/prefix2"},
+			args: []string{"-prefix", "/prefix1"},
+			env:  map[string]string{"PREFIX": "/prefix2"},
 			wantCfg: &config{
 				ListenHost:  defaultListenHost,
 				ListenPort:  defaultListenPort,
@@ -256,7 +255,7 @@ func TestLoadConfig(t *testing.T) {
 			},
 		},
 		"ok PREFIX": {
-			optionsEnv: map[string]string{"PREFIX": "/prefix2"},
+			env: map[string]string{"PREFIX": "/prefix2"},
 			wantCfg: &config{
 				ListenHost:  defaultListenHost,
 				ListenPort:  defaultListenPort,
@@ -292,7 +291,7 @@ func TestLoadConfig(t *testing.T) {
 			},
 		},
 		"ok https env": {
-			optionsEnv: map[string]string{
+			env: map[string]string{
 				"HTTPS_CERT_FILE": "/tmp/test.crt",
 				"HTTPS_KEY_FILE":  "/tmp/test.key",
 			},
@@ -311,7 +310,7 @@ func TestLoadConfig(t *testing.T) {
 				"-https-cert-file", "/tmp/cli.crt",
 				"-https-key-file", "/tmp/cli.key",
 			},
-			optionsEnv: map[string]string{
+			env: map[string]string{
 				"HTTPS_CERT_FILE": "/tmp/env.crt",
 				"HTTPS_KEY_FILE":  "/tmp/env.key",
 			},
@@ -373,7 +372,7 @@ func TestLoadConfig(t *testing.T) {
 			},
 		},
 		"ok USE_REAL_HOSTNAME=1": {
-			optionsEnv: map[string]string{"USE_REAL_HOSTNAME": "1"},
+			env: map[string]string{"USE_REAL_HOSTNAME": "1"},
 			wantCfg: &config{
 				ListenHost:   "0.0.0.0",
 				ListenPort:   8080,
@@ -384,7 +383,7 @@ func TestLoadConfig(t *testing.T) {
 			},
 		},
 		"ok USE_REAL_HOSTNAME=true": {
-			optionsEnv: map[string]string{"USE_REAL_HOSTNAME": "true"},
+			env: map[string]string{"USE_REAL_HOSTNAME": "true"},
 			wantCfg: &config{
 				ListenHost:   "0.0.0.0",
 				ListenPort:   8080,
@@ -396,7 +395,7 @@ func TestLoadConfig(t *testing.T) {
 		},
 		// case sensitive
 		"ok USE_REAL_HOSTNAME=TRUE": {
-			optionsEnv: map[string]string{"USE_REAL_HOSTNAME": "TRUE"},
+			env: map[string]string{"USE_REAL_HOSTNAME": "TRUE"},
 			wantCfg: &config{
 				ListenHost:  "0.0.0.0",
 				ListenPort:  8080,
@@ -406,7 +405,7 @@ func TestLoadConfig(t *testing.T) {
 			},
 		},
 		"ok USE_REAL_HOSTNAME=false": {
-			optionsEnv: map[string]string{"USE_REAL_HOSTNAME": "false"},
+			env: map[string]string{"USE_REAL_HOSTNAME": "false"},
 			wantCfg: &config{
 				ListenHost:  "0.0.0.0",
 				ListenPort:  8080,
@@ -416,7 +415,7 @@ func TestLoadConfig(t *testing.T) {
 			},
 		},
 		"err real hostname error": {
-			optionsEnv:  map[string]string{"USE_REAL_HOSTNAME": "true"},
+			env:         map[string]string{"USE_REAL_HOSTNAME": "true"},
 			getHostname: func() (string, error) { return "", errors.New("hostname error") },
 			wantErr:     errors.New("could not look up real hostname: hostname error"),
 		},
@@ -434,7 +433,7 @@ func TestLoadConfig(t *testing.T) {
 			},
 		},
 		"ok ALLOWED_REDIRECT_DOMAINS": {
-			optionsEnv: map[string]string{"ALLOWED_REDIRECT_DOMAINS": "foo,bar"},
+			env: map[string]string{"ALLOWED_REDIRECT_DOMAINS": "foo,bar"},
 			wantCfg: &config{
 				ListenHost:             "0.0.0.0",
 				ListenPort:             8080,
@@ -445,8 +444,8 @@ func TestLoadConfig(t *testing.T) {
 			},
 		},
 		"ok allowed redirect domains CLI takes precedence over env": {
-			args:       []string{"-allowed-redirect-domains", "foo.cli,bar.cli"},
-			optionsEnv: map[string]string{"ALLOWED_REDIRECT_DOMAINS": "foo.env,bar.env"},
+			args: []string{"-allowed-redirect-domains", "foo.cli,bar.cli"},
+			env:  map[string]string{"ALLOWED_REDIRECT_DOMAINS": "foo.env,bar.env"},
 			wantCfg: &config{
 				ListenHost:             "0.0.0.0",
 				ListenPort:             8080,
@@ -497,7 +496,7 @@ func TestLoadConfig(t *testing.T) {
 			},
 		},
 		"ok use json log format using LOG_FORMAT env": {
-			optionsEnv: map[string]string{"LOG_FORMAT": "json"},
+			env: map[string]string{"LOG_FORMAT": "json"},
 			wantCfg: &config{
 				ListenHost:  "0.0.0.0",
 				ListenPort:  8080,
@@ -516,7 +515,7 @@ func TestLoadConfig(t *testing.T) {
 			if tc.getHostname == nil {
 				tc.getHostname = getHostnameDefault
 			}
-			cfg, err := loadConfig(tc.args, func(key string) string { return tc.optionsEnv[key] }, tc.getHostname)
+			cfg, err := loadConfig(tc.args, func(key string) string { return tc.env[key] }, tc.getHostname)
 
 			switch {
 			case tc.wantErr != nil && err != nil:

--- a/httpbin/cmd/cmd_test.go
+++ b/httpbin/cmd/cmd_test.go
@@ -53,8 +53,9 @@ func TestLoadConfig(t *testing.T) {
 
 	testCases := map[string]struct {
 		args        []string
-		env         map[string]string
+		optionsEnv  map[string]string
 		getHostname func() (string, error)
+		env         []string
 		wantCfg     *config
 		wantErr     error
 		wantOut     string
@@ -83,8 +84,8 @@ func TestLoadConfig(t *testing.T) {
 			wantErr: errors.New("invalid value \"foo\" for flag -max-body-size: parse error"),
 		},
 		"invalid MAX_BODY_SIZE": {
-			env:     map[string]string{"MAX_BODY_SIZE": "foo"},
-			wantErr: errors.New("invalid value \"foo\" for env var MAX_BODY_SIZE: parse error"),
+			optionsEnv: map[string]string{"MAX_BODY_SIZE": "foo"},
+			wantErr:    errors.New("invalid value \"foo\" for env var MAX_BODY_SIZE: parse error"),
 		},
 		"ok -max-body-size": {
 			args: []string{"-max-body-size", "99"},
@@ -97,7 +98,7 @@ func TestLoadConfig(t *testing.T) {
 			},
 		},
 		"ok MAX_BODY_SIZE": {
-			env: map[string]string{"MAX_BODY_SIZE": "9999"},
+			optionsEnv: map[string]string{"MAX_BODY_SIZE": "9999"},
 			wantCfg: &config{
 				ListenHost:  "0.0.0.0",
 				ListenPort:  8080,
@@ -107,8 +108,8 @@ func TestLoadConfig(t *testing.T) {
 			},
 		},
 		"ok max body size CLI takes precedence over env": {
-			args: []string{"-max-body-size", "1234"},
-			env:  map[string]string{"MAX_BODY_SIZE": "5678"},
+			args:       []string{"-max-body-size", "1234"},
+			optionsEnv: map[string]string{"MAX_BODY_SIZE": "5678"},
 			wantCfg: &config{
 				ListenHost:  "0.0.0.0",
 				ListenPort:  8080,
@@ -124,8 +125,8 @@ func TestLoadConfig(t *testing.T) {
 			wantErr: errors.New("invalid value \"foo\" for flag -max-duration: parse error"),
 		},
 		"invalid MAX_DURATION": {
-			env:     map[string]string{"MAX_DURATION": "foo"},
-			wantErr: errors.New("invalid value \"foo\" for env var MAX_DURATION: parse error"),
+			optionsEnv: map[string]string{"MAX_DURATION": "foo"},
+			wantErr:    errors.New("invalid value \"foo\" for env var MAX_DURATION: parse error"),
 		},
 		"ok -max-duration": {
 			args: []string{"-max-duration", "99s"},
@@ -138,7 +139,7 @@ func TestLoadConfig(t *testing.T) {
 			},
 		},
 		"ok MAX_DURATION": {
-			env: map[string]string{"MAX_DURATION": "9999s"},
+			optionsEnv: map[string]string{"MAX_DURATION": "9999s"},
 			wantCfg: &config{
 				ListenHost:  "0.0.0.0",
 				ListenPort:  8080,
@@ -148,8 +149,8 @@ func TestLoadConfig(t *testing.T) {
 			},
 		},
 		"ok max duration size CLI takes precedence over env": {
-			args: []string{"-max-duration", "1234s"},
-			env:  map[string]string{"MAX_DURATION": "5678s"},
+			args:       []string{"-max-duration", "1234s"},
+			optionsEnv: map[string]string{"MAX_DURATION": "5678s"},
 			wantCfg: &config{
 				ListenHost:  "0.0.0.0",
 				ListenPort:  8080,
@@ -171,7 +172,7 @@ func TestLoadConfig(t *testing.T) {
 			},
 		},
 		"ok HOST": {
-			env: map[string]string{"HOST": "192.0.0.2"},
+			optionsEnv: map[string]string{"HOST": "192.0.0.2"},
 			wantCfg: &config{
 				ListenHost:  "192.0.0.2",
 				ListenPort:  8080,
@@ -181,8 +182,8 @@ func TestLoadConfig(t *testing.T) {
 			},
 		},
 		"ok host cli takes precedence over end": {
-			args: []string{"-host", "99.99.99.99"},
-			env:  map[string]string{"HOST": "11.11.11.11"},
+			args:       []string{"-host", "99.99.99.99"},
+			optionsEnv: map[string]string{"HOST": "11.11.11.11"},
 			wantCfg: &config{
 				ListenHost:  "99.99.99.99",
 				ListenPort:  8080,
@@ -198,8 +199,8 @@ func TestLoadConfig(t *testing.T) {
 			wantErr: errors.New("invalid value \"foo\" for flag -port: parse error"),
 		},
 		"invalid PORT": {
-			env:     map[string]string{"PORT": "foo"},
-			wantErr: errors.New("invalid value \"foo\" for env var PORT: parse error"),
+			optionsEnv: map[string]string{"PORT": "foo"},
+			wantErr:    errors.New("invalid value \"foo\" for env var PORT: parse error"),
 		},
 		"ok -port": {
 			args: []string{"-port", "99"},
@@ -212,7 +213,7 @@ func TestLoadConfig(t *testing.T) {
 			},
 		},
 		"ok PORT": {
-			env: map[string]string{"PORT": "9999"},
+			optionsEnv: map[string]string{"PORT": "9999"},
 			wantCfg: &config{
 				ListenHost:  defaultListenHost,
 				ListenPort:  9999,
@@ -222,8 +223,8 @@ func TestLoadConfig(t *testing.T) {
 			},
 		},
 		"ok port CLI takes precedence over env": {
-			args: []string{"-port", "1234"},
-			env:  map[string]string{"PORT": "5678"},
+			args:       []string{"-port", "1234"},
+			optionsEnv: map[string]string{"PORT": "5678"},
 			wantCfg: &config{
 				ListenHost:  defaultListenHost,
 				ListenPort:  1234,
@@ -243,8 +244,8 @@ func TestLoadConfig(t *testing.T) {
 			wantErr: errors.New("Prefix \"/invalidprefix2/\" must not end with a slash"),
 		},
 		"ok -prefix takes precedence over env": {
-			args: []string{"-prefix", "/prefix1"},
-			env:  map[string]string{"PREFIX": "/prefix2"},
+			args:       []string{"-prefix", "/prefix1"},
+			optionsEnv: map[string]string{"PREFIX": "/prefix2"},
 			wantCfg: &config{
 				ListenHost:  defaultListenHost,
 				ListenPort:  defaultListenPort,
@@ -255,7 +256,7 @@ func TestLoadConfig(t *testing.T) {
 			},
 		},
 		"ok PREFIX": {
-			env: map[string]string{"PREFIX": "/prefix2"},
+			optionsEnv: map[string]string{"PREFIX": "/prefix2"},
 			wantCfg: &config{
 				ListenHost:  defaultListenHost,
 				ListenPort:  defaultListenPort,
@@ -291,7 +292,7 @@ func TestLoadConfig(t *testing.T) {
 			},
 		},
 		"ok https env": {
-			env: map[string]string{
+			optionsEnv: map[string]string{
 				"HTTPS_CERT_FILE": "/tmp/test.crt",
 				"HTTPS_KEY_FILE":  "/tmp/test.key",
 			},
@@ -310,7 +311,7 @@ func TestLoadConfig(t *testing.T) {
 				"-https-cert-file", "/tmp/cli.crt",
 				"-https-key-file", "/tmp/cli.key",
 			},
-			env: map[string]string{
+			optionsEnv: map[string]string{
 				"HTTPS_CERT_FILE": "/tmp/env.crt",
 				"HTTPS_KEY_FILE":  "/tmp/env.key",
 			},
@@ -372,7 +373,7 @@ func TestLoadConfig(t *testing.T) {
 			},
 		},
 		"ok USE_REAL_HOSTNAME=1": {
-			env: map[string]string{"USE_REAL_HOSTNAME": "1"},
+			optionsEnv: map[string]string{"USE_REAL_HOSTNAME": "1"},
 			wantCfg: &config{
 				ListenHost:   "0.0.0.0",
 				ListenPort:   8080,
@@ -383,7 +384,7 @@ func TestLoadConfig(t *testing.T) {
 			},
 		},
 		"ok USE_REAL_HOSTNAME=true": {
-			env: map[string]string{"USE_REAL_HOSTNAME": "true"},
+			optionsEnv: map[string]string{"USE_REAL_HOSTNAME": "true"},
 			wantCfg: &config{
 				ListenHost:   "0.0.0.0",
 				ListenPort:   8080,
@@ -395,7 +396,7 @@ func TestLoadConfig(t *testing.T) {
 		},
 		// case sensitive
 		"ok USE_REAL_HOSTNAME=TRUE": {
-			env: map[string]string{"USE_REAL_HOSTNAME": "TRUE"},
+			optionsEnv: map[string]string{"USE_REAL_HOSTNAME": "TRUE"},
 			wantCfg: &config{
 				ListenHost:  "0.0.0.0",
 				ListenPort:  8080,
@@ -405,7 +406,7 @@ func TestLoadConfig(t *testing.T) {
 			},
 		},
 		"ok USE_REAL_HOSTNAME=false": {
-			env: map[string]string{"USE_REAL_HOSTNAME": "false"},
+			optionsEnv: map[string]string{"USE_REAL_HOSTNAME": "false"},
 			wantCfg: &config{
 				ListenHost:  "0.0.0.0",
 				ListenPort:  8080,
@@ -415,7 +416,7 @@ func TestLoadConfig(t *testing.T) {
 			},
 		},
 		"err real hostname error": {
-			env:         map[string]string{"USE_REAL_HOSTNAME": "true"},
+			optionsEnv:  map[string]string{"USE_REAL_HOSTNAME": "true"},
 			getHostname: func() (string, error) { return "", errors.New("hostname error") },
 			wantErr:     errors.New("could not look up real hostname: hostname error"),
 		},
@@ -433,7 +434,7 @@ func TestLoadConfig(t *testing.T) {
 			},
 		},
 		"ok ALLOWED_REDIRECT_DOMAINS": {
-			env: map[string]string{"ALLOWED_REDIRECT_DOMAINS": "foo,bar"},
+			optionsEnv: map[string]string{"ALLOWED_REDIRECT_DOMAINS": "foo,bar"},
 			wantCfg: &config{
 				ListenHost:             "0.0.0.0",
 				ListenPort:             8080,
@@ -444,8 +445,8 @@ func TestLoadConfig(t *testing.T) {
 			},
 		},
 		"ok allowed redirect domains CLI takes precedence over env": {
-			args: []string{"-allowed-redirect-domains", "foo.cli,bar.cli"},
-			env:  map[string]string{"ALLOWED_REDIRECT_DOMAINS": "foo.env,bar.env"},
+			args:       []string{"-allowed-redirect-domains", "foo.cli,bar.cli"},
+			optionsEnv: map[string]string{"ALLOWED_REDIRECT_DOMAINS": "foo.env,bar.env"},
 			wantCfg: &config{
 				ListenHost:             "0.0.0.0",
 				ListenPort:             8080,
@@ -496,7 +497,7 @@ func TestLoadConfig(t *testing.T) {
 			},
 		},
 		"ok use json log format using LOG_FORMAT env": {
-			env: map[string]string{"LOG_FORMAT": "json"},
+			optionsEnv: map[string]string{"LOG_FORMAT": "json"},
 			wantCfg: &config{
 				ListenHost:  "0.0.0.0",
 				ListenPort:  8080,
@@ -515,7 +516,7 @@ func TestLoadConfig(t *testing.T) {
 			if tc.getHostname == nil {
 				tc.getHostname = getHostnameDefault
 			}
-			cfg, err := loadConfig(tc.args, func(key string) string { return tc.env[key] }, tc.getHostname)
+			cfg, err := loadConfig(tc.args, func(key string) string { return tc.optionsEnv[key] }, tc.getHostname)
 
 			switch {
 			case tc.wantErr != nil && err != nil:

--- a/httpbin/cmd/cmd_test.go
+++ b/httpbin/cmd/cmd_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"flag"
+	"fmt"
 	"os"
 	"reflect"
 	"testing"
@@ -540,9 +541,8 @@ func TestMainImpl(t *testing.T) {
 
 	testCases := map[string]struct {
 		args        []string
-		optionsEnv  map[string]string
+		env         map[string]string
 		getHostname func() (string, error)
-		env         []string
 		wantCode    int
 		wantOut     string
 		wantOutFn   func(t *testing.T, out string)
@@ -607,7 +607,7 @@ func TestMainImpl(t *testing.T) {
 			}
 
 			buf := &bytes.Buffer{}
-			gotCode := mainImpl(tc.args, func(key string) string { return tc.optionsEnv[key] }, func() []string { return tc.env }, tc.getHostname, buf)
+			gotCode := mainImpl(tc.args, func(key string) string { return tc.env[key] }, func() []string { return environSlice(tc.env) }, tc.getHostname, buf)
 			out := buf.String()
 
 			if gotCode != tc.wantCode {
@@ -625,4 +625,12 @@ func TestMainImpl(t *testing.T) {
 			}
 		})
 	}
+}
+
+func environSlice(env map[string]string) []string {
+	envStrings := make([]string, 0, len(env))
+	for name, value := range env {
+		envStrings = append(envStrings, fmt.Sprintf("%s=%s", name, value))
+	}
+	return envStrings
 }

--- a/httpbin/handlers.go
+++ b/httpbin/handlers.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -33,6 +34,22 @@ func (h *HTTPBin) Index(w http.ResponseWriter, r *http.Request) {
 	}
 	w.Header().Set("Content-Security-Policy", "default-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' camo.githubusercontent.com")
 	writeHTML(w, h.indexHTML, http.StatusOK)
+}
+
+// Env - returns environment variables with HTTPBIN_ prefix, if any pre-configured by operator
+func (h *HTTPBin) Env(w http.ResponseWriter, _ *http.Request) {
+	variables := make(map[string]string)
+	for _, e := range os.Environ() {
+		v := strings.SplitN(e, "=", 2)
+		if !strings.HasPrefix(v[0], "HTTPBIN_") {
+			continue
+		}
+		variables[v[0]] = v[1]
+	}
+
+	writeJSON(http.StatusOK, w, &environmentResponse{
+		Environment: variables,
+	})
 }
 
 // FormsPost renders an HTML form that submits a request to the /post endpoint

--- a/httpbin/handlers.go
+++ b/httpbin/handlers.go
@@ -47,8 +47,8 @@ func (h *HTTPBin) Env(w http.ResponseWriter, _ *http.Request) {
 		variables[v[0]] = v[1]
 	}
 
-	writeJSON(http.StatusOK, w, &environmentResponse{
-		Environment: variables,
+	writeJSON(http.StatusOK, w, &envResponse{
+		Env: variables,
 	})
 }
 

--- a/httpbin/handlers.go
+++ b/httpbin/handlers.go
@@ -11,7 +11,6 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"net/url"
-	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -38,17 +37,8 @@ func (h *HTTPBin) Index(w http.ResponseWriter, r *http.Request) {
 
 // Env - returns environment variables with HTTPBIN_ prefix, if any pre-configured by operator
 func (h *HTTPBin) Env(w http.ResponseWriter, _ *http.Request) {
-	variables := make(map[string]string)
-	for _, e := range os.Environ() {
-		v := strings.SplitN(e, "=", 2)
-		if !strings.HasPrefix(v[0], "HTTPBIN_") {
-			continue
-		}
-		variables[v[0]] = v[1]
-	}
-
 	writeJSON(http.StatusOK, w, &envResponse{
-		Env: variables,
+		Env: h.env,
 	})
 }
 

--- a/httpbin/handlers_test.go
+++ b/httpbin/handlers_test.go
@@ -125,8 +125,8 @@ func TestEnv(t *testing.T) {
 		t.Parallel()
 		req := newTestRequest(t, "GET", "/env")
 		resp := must.DoReq(t, client, req)
-		result := mustParseResponse[environmentResponse](t, resp)
-		assert.Equal(t, len(result.Environment), 0, "environment variables unexpeced")
+		result := mustParseResponse[envResponse](t, resp)
+		assert.Equal(t, len(result.Env), 0, "environment variables unexpected")
 	})
 }
 

--- a/httpbin/handlers_test.go
+++ b/httpbin/handlers_test.go
@@ -120,6 +120,16 @@ func TestIndex(t *testing.T) {
 	}
 }
 
+func TestEnv(t *testing.T) {
+	t.Run("default environment", func(t *testing.T) {
+		t.Parallel()
+		req := newTestRequest(t, "GET", "/env")
+		resp := must.DoReq(t, client, req)
+		result := mustParseResponse[environmentResponse](t, resp)
+		assert.Equal(t, len(result.Environment), 0, "environment variables unexpeced")
+	})
+}
+
 func TestFormsPost(t *testing.T) {
 	t.Parallel()
 

--- a/httpbin/httpbin.go
+++ b/httpbin/httpbin.go
@@ -57,6 +57,10 @@ type HTTPBin struct {
 	// Set of hosts to which the /redirect-to endpoint will allow redirects
 	AllowedRedirectDomains map[string]struct{}
 
+	// The operator-controlled environment variables filtered from
+	// the process environment, based on named HTTPBIN_ prefix.
+	env map[string]string
+
 	// Pre-computed error message for the /redirect-to endpoint, based on
 	// -allowed-redirect-domains/ALLOWED_REDIRECT_DOMAINS
 	forbiddenRedirectError string

--- a/httpbin/httpbin.go
+++ b/httpbin/httpbin.go
@@ -159,6 +159,7 @@ func (h *HTTPBin) Handler() http.Handler {
 	mux.HandleFunc("/digest-auth/{qop}/{user}/{password}/{algorithm}", h.DigestAuth)
 	mux.HandleFunc("/drip", h.Drip)
 	mux.HandleFunc("/dump/request", h.DumpRequest)
+	mux.HandleFunc("/env", h.Env)
 	mux.HandleFunc("/etag/{etag}", h.ETag)
 	mux.HandleFunc("/gzip", h.Gzip)
 	mux.HandleFunc("/headers", h.Headers)

--- a/httpbin/options.go
+++ b/httpbin/options.go
@@ -46,6 +46,14 @@ func WithObserver(o Observer) OptionFunc {
 	}
 }
 
+// WithEnv sets the HTTPBIN_-prefixed environment variables reported
+// by the /env endpoint.
+func WithEnv(env map[string]string) OptionFunc {
+	return func(h *HTTPBin) {
+		h.env = env
+	}
+}
+
 // WithExcludeHeaders sets the headers to exclude in outgoing responses, to
 // prevent possible information leakage.
 func WithExcludeHeaders(excludeHeaders string) OptionFunc {

--- a/httpbin/responses.go
+++ b/httpbin/responses.go
@@ -13,8 +13,8 @@ const (
 	textContentType   = "text/plain; charset=utf-8"
 )
 
-type environmentResponse struct {
-	Environment map[string]string `json:"env"`
+type envResponse struct {
+	Env map[string]string `json:"env"`
 }
 
 type headersResponse struct {

--- a/httpbin/responses.go
+++ b/httpbin/responses.go
@@ -13,6 +13,10 @@ const (
 	textContentType   = "text/plain; charset=utf-8"
 )
 
+type environmentResponse struct {
+	Environment map[string]string `json:"env"`
+}
+
 type headersResponse struct {
 	Headers http.Header `json:"headers"`
 }

--- a/httpbin/static/index.html.tmpl
+++ b/httpbin/static/index.html.tmpl
@@ -82,7 +82,7 @@
 <li><a href="{{.Prefix}}/drip?code=200&amp;numbytes=5&amp;duration=5"><code>{{.Prefix}}/drip?numbytes=n&amp;duration=s&amp;delay=s&amp;code=code</code></a> Drips data over the given duration after an optional initial delay, simulating a slow HTTP server.</li>
 <li><a href="{{.Prefix}}/dump/request"><code>{{.Prefix}}/dump/request</code></a> Returns the given request in its HTTP/1.x wire approximate representation.</li>
 <li><a href="{{.Prefix}}/encoding/utf8"><code>{{.Prefix}}/encoding/utf8</code></a> Returns page containing UTF-8 data.</li>
-<li><a href="{{.Prefix}}/env"><code>{{.Prefix}}/env</code></a> Returns all environment variables named with <code>HTTPBIN_</code> prefix.</li>
+<li><a href="{{.Prefix}}/env"><code>{{.Prefix}}/env</code></a> Returns all environment variables named with <code>HTTPBIN_ENV_</code> prefix.</li>
 <li><a href="{{.Prefix}}/etag/etag"><code>{{.Prefix}}/etag/:etag</code></a> Assumes the resource has the given etag and responds to If-None-Match header with a 200 or 304 and If-Match with a 200 or 412 as appropriate.</li>
 <li><a href="{{.Prefix}}/forms/post"><code>{{.Prefix}}/forms/post</code></a> HTML form that submits to <em>{{.Prefix}}/post</em></li>
 <li><a href="{{.Prefix}}/get"><code>{{.Prefix}}/get</code></a> Returns GET data.</li>

--- a/httpbin/static/index.html.tmpl
+++ b/httpbin/static/index.html.tmpl
@@ -82,6 +82,7 @@
 <li><a href="{{.Prefix}}/drip?code=200&amp;numbytes=5&amp;duration=5"><code>{{.Prefix}}/drip?numbytes=n&amp;duration=s&amp;delay=s&amp;code=code</code></a> Drips data over the given duration after an optional initial delay, simulating a slow HTTP server.</li>
 <li><a href="{{.Prefix}}/dump/request"><code>{{.Prefix}}/dump/request</code></a> Returns the given request in its HTTP/1.x wire approximate representation.</li>
 <li><a href="{{.Prefix}}/encoding/utf8"><code>{{.Prefix}}/encoding/utf8</code></a> Returns page containing UTF-8 data.</li>
+<li><a href="{{.Prefix}}/env"><code>{{.Prefix}}/env</code></a> Returns all environment variables named with <code>HTTPBIN_</code> prefix.</li>
 <li><a href="{{.Prefix}}/etag/etag"><code>{{.Prefix}}/etag/:etag</code></a> Assumes the resource has the given etag and responds to If-None-Match header with a 200 or 304 and If-Match with a 200 or 412 as appropriate.</li>
 <li><a href="{{.Prefix}}/forms/post"><code>{{.Prefix}}/forms/post</code></a> HTML form that submits to <em>{{.Prefix}}/post</em></li>
 <li><a href="{{.Prefix}}/get"><code>{{.Prefix}}/get</code></a> Returns GET data.</li>


### PR DESCRIPTION
Proposal of implementation of the feature request
- #114

----

I've submitted this for an initial round of review. 
I still have to add more cases to the test and add the endpoint to the index page, but first I'd like to receive feedback if this implementation goes in the right direction.

----

```bash
make run

curl http://127.0.0.1:8080/env
{
  "env": {}
}

export HTTPBIN_A=a
export HTTPBIN_B=b
export HTTPBIN_123=123

make run

curl http://127.0.0.1:8080/env
{
  "env": {
    "HTTPBIN_123": "123",
    "HTTPBIN_A": "a",
    "HTTPBIN_B": "b"
  }
}
```
