### PR TITLE
ci: push to ghcr.io in addition to docker hub

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,9 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
       - uses: docker/setup-qemu-action@v2
-
       - uses: docker/setup-buildx-action@v2
 
       - uses: docker/login-action@v2
@@ -26,10 +24,17 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - uses: docker/metadata-action@v4
         with:
           images: |
             mccutchen/go-httpbin
+            ghcr.io/${{ github.repository }}
         id: meta
 
       - uses: docker/build-push-action@v3


### PR DESCRIPTION
Motivated by Docker's much more aggressive [rate limits on unauthenticated pulls of public images](https://docs.docker.com/docker-hub/usage/) going into effect on April 1:

> Unauthenticated users and users with a free Personal account have the following pull limits:
> * Unauthenticated users: 10 pulls/hour

Just gonna merge this and stamp a new release to see what happens, I guess?