### PR TITLE
Ci/ghcr ii

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,6 +10,8 @@ name: Release
 "on":
   release:
     types: [published]
+  pull_request:
+    branches: [main]
 
 jobs:
   docker:
@@ -21,30 +23,44 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: docker/setup-qemu-action@v2
-      - uses: docker/setup-buildx-action@v2
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
 
-      - uses: docker/login-action@v2
+      - uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - uses: docker/login-action@v2
+      - uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: docker/metadata-action@v4
+      - id: pr-sha
+        if: github.event_name == 'pull_request'
+        run: echo "sha=$(git rev-parse --short ${{ github.event.pull_request.head.sha }})" >> $GITHUB_OUTPUT
+
+      - uses: docker/metadata-action@v5
         with:
           images: |
             mccutchen/go-httpbin
             ghcr.io/${{ github.repository }}
+          tags: |
+            # For releases, use the standard tags and special "latest" tag
+            type=semver,pattern={{version}},enable=${{ github.event_name == 'release' }}
+            type=semver,pattern={{major}}.{{minor}},enable=${{ github.event_name == 'release' }}
+            type=raw,value=latest,enable=${{ github.event_name == 'release' }}
+            # For pull requests, use the commit SHA
+            type=raw,value=${{ steps.pr-sha.outputs.sha }},enable=${{ github.event_name == 'pull_request' }}
         id: meta
 
-      - uses: docker/build-push-action@v3
+      - uses: docker/build-push-action@v6
         with:
           platforms: linux/amd64,linux/arm64
           push: true
+          sbom: true
+          provenance: mode=max
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          annotations: ${{ steps.meta.outputs.annotations }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,6 +14,11 @@ name: Release
 jobs:
   docker:
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+
     steps:
       - uses: actions/checkout@v4
       - uses: docker/setup-qemu-action@v2


### PR DESCRIPTION
The change in #200 to push images to ghcr.io in addition to docker hub failed with an authentication error:

> ERROR: failed to solve: failed to push ghcr.io/***/go-httpbin:v2.17.0: unexpected status from POST request to https://ghcr.io/v2/***/go-httpbin/blobs/uploads/: 403 Forbidden

Here's one attempt to fix it, while also updating various deps and improving other metadata.