### PR TITLE
fix: /response-headers does not need escaping by default

### DIFF
--- a/httpbin/handlers.go
+++ b/httpbin/handlers.go
@@ -341,18 +341,22 @@ func (h *HTTPBin) Unstable(w http.ResponseWriter, r *http.Request) {
 // values in the JSON response body will be escaped.
 func (h *HTTPBin) ResponseHeaders(w http.ResponseWriter, r *http.Request) {
 	args := r.URL.Query()
-	contentType := args.Get("Content-Type")
 
-	// response headers are not escaped, regardless of content type
+	// only set our own content type if one was not already set based on
+	// incoming request params
+	contentType := args.Get("Content-Type")
+	if contentType == "" {
+		contentType = jsonContentType
+		args.Set("Content-Type", contentType)
+	}
+
+	// actual HTTP response headers are not escaped, regardless of content type
+	// (unlike the JSON serialized representation of those headers in the
+	// response body, which MAY be escaped based on content type)
 	for k, vs := range args {
 		for _, v := range vs {
 			w.Header().Add(k, v)
 		}
-	}
-	// only set our own content type if one was not already set based on
-	// incoming request params
-	if contentType == "" {
-		w.Header().Set("Content-Type", jsonContentType)
 	}
 
 	// if response content type is dangrous, escape keys and values before

--- a/httpbin/handlers_test.go
+++ b/httpbin/handlers_test.go
@@ -1241,6 +1241,13 @@ func TestResponseHeaders(t *testing.T) {
 			resultValues := result[k]
 			assert.DeepEqual(t, resultValues, expectedValues, "JSON response headers mismatch")
 		}
+
+		// if no content-type is specified in the request params, the response
+		// defaults to JSON.
+		//
+		// Note that if this changes, we need to ensure we maintain safety
+		// around escapig HTML in the response (see the subtest below)
+		assert.Header(t, resp, "Content-Type", jsonContentType)
 	})
 
 	t.Run("override content-type", func(t *testing.T) {
@@ -1271,8 +1278,11 @@ func TestResponseHeaders(t *testing.T) {
 			{"text/plain", false},
 			{"application/octet-string", false},
 
+			// if no content-type is provided, we default to JSON, which is
+			// safe
+			{"", false},
+
 			// everything else requires escaping
-			{"", true},
 			{"application/xml", true},
 			{"image/png", true},
 			{"text/html; charset=utf8", true},


### PR DESCRIPTION
So it turns out that the fix for https://github.com/mccutchen/go-httpbin/security/advisories/GHSA-528q-4pgm-wvg2 in https://github.com/mccutchen/go-httpbin/commit/0decfd1a2e88d85ca6bfb8a92421653f647cbc04 made an unintentionally breaking change, by HTML-escaping the body of the `/response-headers` response when no explicit `Content-Type` is specified in the incoming request.  We do not need to escape by default, because the response will be returned as JSON by default.

This was uncovered by @alxndrsn in https://github.com/mccutchen/go-httpbin/issues/207, a separate issue with the `/response-headers` endpoint.