### PR TITLE
fix: small fixup to new `/ip` test case

### DIFF
--- a/httpbin/handlers_test.go
+++ b/httpbin/handlers_test.go
@@ -412,8 +412,7 @@ func TestIP(t *testing.T) {
 		// connections but not for direct ServeHTTP calls as the used in the
 		// httptest.NewRecorder tests above, so we need to use a real server
 		// to verify handling of both cases.
-		srv := httptest.NewServer(app)
-		defer srv.Close()
+		t.Parallel()
 
 		resp, err := client.Get(srv.URL + "/ip")
 		assert.NilError(t, err)


### PR DESCRIPTION
Really made a mess of fixing #211.  Here I realized that the test added in #213 (which tests #212) had a couple of small-ish issues:
- Missing `t.Parallel()` call, unnecessarily slowing down overall test suite
- No need to spin up new ephemeral test server, prefer the existing shared one