### PR TITLE
chore: update autobahn docker image tag

### DIFF
--- a/httpbin/websocket/websocket_autobahn_test.go
+++ b/httpbin/websocket/websocket_autobahn_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/mccutchen/go-httpbin/v2/internal/testing/assert"
 )
 
-const autobahnImage = "crossbario/autobahn-testsuite:0.8.2"
+const autobahnImage = "crossbario/autobahn-testsuite:25.10.1"
 
 var defaultIncludedTestCases = []string{
 	"*",


### PR DESCRIPTION
Apparently they just deleted old image tags when they pushed a new release?
https://hub.docker.com/r/crossbario/autobahn-testsuite/tags