### PR TITLE
feat: add `/server-ip` endpoint to return server's local IP address

### DIFF
--- a/httpbin/handlers.go
+++ b/httpbin/handlers.go
@@ -166,6 +166,13 @@ func (h *HTTPBin) Headers(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// ServerIP echoes the IP address of the server handling the request
+func (h *HTTPBin) ServerIP(w http.ResponseWriter, _ *http.Request) {
+	writeJSON(http.StatusOK, w, &serverIPResponse{
+		ServerIP: getServerIP(),
+	})
+}
+
 type statusCase struct {
 	headers map[string]string
 	body    []byte

--- a/httpbin/httpbin.go
+++ b/httpbin/httpbin.go
@@ -181,6 +181,7 @@ func (h *HTTPBin) Handler() http.Handler {
 	mux.HandleFunc("/image", h.ImageAccept)
 	mux.HandleFunc("/image/{kind}", h.Image)
 	mux.HandleFunc("/ip", h.IP)
+	mux.HandleFunc("/server-ip", h.ServerIP)
 	mux.HandleFunc("/json", h.JSON)
 	mux.HandleFunc("/links/{numLinks}", h.Links)
 	mux.HandleFunc("/links/{numLinks}/{offset}", h.Links)

--- a/httpbin/responses.go
+++ b/httpbin/responses.go
@@ -87,6 +87,10 @@ type hostnameResponse struct {
 	Hostname string `json:"hostname"`
 }
 
+type serverIPResponse struct {
+	ServerIP string `json:"server_ip"`
+}
+
 type errorRespnose struct {
 	StatusCode int    `json:"status_code"`
 	Error      string `json:"error"`


### PR DESCRIPTION
This change introduces a new /server-ip endpoint that returns the IP address of the server (or Pod in Kubernetes) handling the request, as opposed to the existing /ip endpoint which returns the client's IP address.

Changes:
- Add getServerIP() helper in helpers.go to detect server's primary IP
  - Prefers non-loopback IPv4 addresses
  - Falls back to IPv6 if no IPv4 found
  - Uses UDP dial as last resort for IP detection
- Add ServerIP handler in handlers.go
- Register /server-ip route in httpbin.go
- Add serverIPResponse struct in responses.go

This is useful for debugging and service discovery in containerized environments where the server's IP may need to be identified.