### PR TITLE
feat: add /jsonl endpoint, support jitter on sse

### DIFF
--- a/httpbin/handlers.go
+++ b/httpbin/handlers.go
@@ -1182,6 +1182,112 @@ func (h *HTTPBin) JSON(w http.ResponseWriter, _ *http.Request) {
 	w.Write(mustStaticAsset("sample.json"))
 }
 
+// JSONL - returns a stream of JSON Lines data, one JSON object per line.
+// Accepts optional query parameters:
+//   - count: number of lines to emit (default 10, clamped to [1, maxJSONLCount])
+//   - duration: total duration over which to stream the lines (e.g. "5s")
+//   - delay: initial delay before streaming begins (e.g. "1s")
+//   - jitter: float in [0, 1] that randomizes pause between lines (e.g. 0.5 = +/-50%)
+func (h *HTTPBin) JSONL(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+
+	var (
+		count    = h.DefaultParams.JSONLCount
+		duration = h.DefaultParams.JSONLDuration
+		delay    = h.DefaultParams.JSONLDelay
+		jitter   float64
+		err      error
+	)
+
+	if userCount := q.Get("count"); userCount != "" {
+		count, err = strconv.Atoi(userCount)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, fmt.Errorf("invalid count: %w", err))
+			return
+		}
+		if count < 1 {
+			count = 1
+		} else if int64(count) > h.maxJSONLCount {
+			count = int(h.maxJSONLCount)
+		}
+	}
+
+	if userDuration := q.Get("duration"); userDuration != "" {
+		duration, err = parseBoundedDuration(userDuration, 1, h.MaxDuration)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, fmt.Errorf("invalid duration: %w", err))
+			return
+		}
+	}
+
+	if userDelay := q.Get("delay"); userDelay != "" {
+		delay, err = parseBoundedDuration(userDelay, 0, h.MaxDuration)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, fmt.Errorf("invalid delay: %w", err))
+			return
+		}
+	}
+
+	if userJitter := q.Get("jitter"); userJitter != "" {
+		jitter, err = strconv.ParseFloat(userJitter, 64)
+		if err != nil || jitter < 0 || jitter > 1 {
+			writeError(w, http.StatusBadRequest, fmt.Errorf("invalid jitter: must be a float in [0, 1]"))
+			return
+		}
+	}
+
+	if duration+delay > h.MaxDuration {
+		http.Error(w, "Too much time", http.StatusBadRequest)
+		return
+	}
+
+	if delay > 0 {
+		select {
+		case <-time.After(delay):
+		case <-r.Context().Done():
+			w.WriteHeader(499)
+			return
+		}
+	}
+
+	w.Header().Set("Content-Type", jsonlContentType)
+
+	resp := &streamResponse{
+		Args:    r.URL.Query(),
+		Headers: getRequestHeaders(r, h.excludeHeadersProcessor),
+		Origin:  getClientIP(r),
+		URL:     getURL(r).String(),
+	}
+	newline := []byte{'\n'}
+	pause := computePausePerWrite(duration, int64(count))
+	flusher := w.(http.Flusher)
+
+	for i := range newPacer(r.Context(), count, pause, jitter) {
+		resp.ID = i
+		line, _ := json.Marshal(resp)
+		w.Write(line)
+		w.Write(newline)
+		flusher.Flush()
+	}
+}
+
+// writeJSONLSample writes a representative JSONL line for estimating line size.
+func writeJSONLSample(w io.Writer) {
+	resp := &streamResponse{
+		ID:   999,
+		Args: map[string][]string{"sample": {"value"}},
+		Headers: http.Header{
+			"Host":       {"example.com"},
+			"User-Agent": {"sample-agent/1.0"},
+		},
+		Origin: "127.0.0.1",
+		URL:    "http://example.com/jsonl?count=100",
+	}
+	line, _ := json.Marshal(resp)
+	w.Write(line)
+	w.Write([]byte{'\n'})
+}
+
 // Bearer - Prompts the user for authorization using bearer authentication.
 func (h *HTTPBin) Bearer(w http.ResponseWriter, r *http.Request) {
 	reqToken := r.Header.Get("Authorization")
@@ -1213,6 +1319,7 @@ func (h *HTTPBin) SSE(w http.ResponseWriter, r *http.Request) {
 		count    = h.DefaultParams.SSECount
 		duration = h.DefaultParams.SSEDuration
 		delay    = h.DefaultParams.SSEDelay
+		jitter   float64
 		err      error
 	)
 
@@ -1240,6 +1347,14 @@ func (h *HTTPBin) SSE(w http.ResponseWriter, r *http.Request) {
 		delay, err = parseBoundedDuration(userDelay, 0, h.MaxDuration)
 		if err != nil {
 			writeError(w, http.StatusBadRequest, fmt.Errorf("invalid delay: %w", err))
+			return
+		}
+	}
+
+	if userJitter := q.Get("jitter"); userJitter != "" {
+		jitter, err = strconv.ParseFloat(userJitter, 64)
+		if err != nil || jitter < 0 || jitter > 1 {
+			writeError(w, http.StatusBadRequest, fmt.Errorf("invalid jitter: must be a float in [0, 1]"))
 			return
 		}
 	}
@@ -1275,32 +1390,9 @@ func (h *HTTPBin) SSE(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 
 	flusher := w.(http.Flusher)
-
-	// special case when we only have one event to write
-	if count == 1 {
-		writeServerSentEvent(w, 0, time.Now())
-		flusher.Flush()
-		return
-	}
-
-	ticker := time.NewTicker(pause)
-	defer ticker.Stop()
-
-	for i := 0; i < count; i++ {
+	for i := range newPacer(r.Context(), count, pause, jitter) {
 		writeServerSentEvent(w, i, time.Now())
 		flusher.Flush()
-
-		// don't pause after last byte
-		if i == count-1 {
-			return
-		}
-
-		select {
-		case <-ticker.C:
-			// ok
-		case <-r.Context().Done():
-			return
-		}
 	}
 }
 

--- a/httpbin/handlers_test.go
+++ b/httpbin/handlers_test.go
@@ -102,9 +102,14 @@ func createApp(opts ...OptionFunc) *HTTPBin {
 			DripDelay:    0,
 			DripDuration: 100 * time.Millisecond,
 			DripNumBytes: 10,
-			SSECount:     10,
-			SSEDelay:     0,
-			SSEDuration:  100 * time.Millisecond,
+
+			SSECount:    10,
+			SSEDelay:    0,
+			SSEDuration: 100 * time.Millisecond,
+
+			JSONLCount:    10,
+			JSONLDelay:    0,
+			JSONLDuration: 0,
 		}),
 		WithMaxBodySize(1024),
 		WithMaxDuration(1*time.Second),
@@ -3272,6 +3277,190 @@ func TestJSON(t *testing.T) {
 	assert.BodyContains(t, resp, `Wake up to WonderWidgets!`)
 }
 
+func TestJSONL(t *testing.T) {
+	t.Parallel()
+
+	app := setupTestApp(t)
+
+	okTests := []struct {
+		url           string
+		expectedLines int
+	}{
+		{"/jsonl", 10},                                          // default count
+		{"/jsonl?count=1", 1},                                   // minimum
+		{"/jsonl?count=5", 5},                                   // custom count
+		{"/jsonl?count=0", 1},                                   // clamped to min
+		{"/jsonl?count=-5", 1},                                  // clamped to min
+		{"/jsonl?count=3&duration=1s", 3},                       // with duration
+		{"/jsonl?count=1&duration=1s", 1},                       // single line with duration
+		{"/jsonl?count=3&delay=0s", 3},                          // with zero delay
+		{"/jsonl?count=2&duration=1s&delay=0s", 2},              // with both
+		{"/jsonl?count=3&duration=1s&jitter=0", 3},              // jitter=0 (no effect)
+		{"/jsonl?count=3&duration=1s&jitter=0.5", 3},            // jitter=0.5
+		{"/jsonl?count=3&duration=1s&jitter=1", 3},              // jitter=1 (max)
+	}
+	for _, test := range okTests {
+		t.Run("ok"+test.url, func(t *testing.T) {
+			t.Parallel()
+
+			req := newTestRequest(t, "GET", app.URL(test.url), nil)
+			resp := mustDoRequest(t, app, req)
+
+			assert.StatusCode(t, resp, http.StatusOK)
+			assert.ContentType(t, resp, jsonlContentType)
+
+			// Expect chunked transfer encoding for streaming
+			assert.Header(t, resp, "Content-Length", "")
+			assert.DeepEqual(t, resp.TransferEncoding, []string{"chunked"}, "expected Transfer-Encoding: chunked")
+
+			i := 0
+			scanner := bufio.NewScanner(resp.Body)
+			for scanner.Scan() {
+				var sr streamResponse
+				err := json.Unmarshal(scanner.Bytes(), &sr)
+				assert.NilError(t, err)
+				assert.Equal(t, sr.ID, i, "bad id")
+				i++
+			}
+			assert.NilError(t, scanner.Err())
+			assert.Equal(t, i, test.expectedLines, "wrong number of lines")
+		})
+	}
+
+	t.Run("ok/count clamped to max", func(t *testing.T) {
+		t.Parallel()
+		maxCount := int(app.App.maxJSONLCount)
+		url := fmt.Sprintf("/jsonl?count=%d", maxCount+500)
+		req := newTestRequest(t, "GET", app.URL(url), nil)
+		resp := mustDoRequest(t, app, req)
+		assert.StatusCode(t, resp, http.StatusOK)
+		i := 0
+		scanner := bufio.NewScanner(resp.Body)
+		for scanner.Scan() {
+			var sr streamResponse
+			err := json.Unmarshal(scanner.Bytes(), &sr)
+			assert.NilError(t, err)
+			i++
+		}
+		assert.NilError(t, scanner.Err())
+		assert.Equal(t, i, maxCount, "wrong number of lines")
+	})
+
+	badTests := []struct {
+		url  string
+		code int
+	}{
+		{"/jsonl?count=foo", http.StatusBadRequest},
+		{"/jsonl?count=3.14", http.StatusBadRequest},
+		{"/jsonl?duration=foo", http.StatusBadRequest},
+		{"/jsonl?delay=foo", http.StatusBadRequest},
+		{"/jsonl?duration=5s&delay=8s", http.StatusBadRequest}, // exceeds max duration
+		{"/jsonl?jitter=-0.1", http.StatusBadRequest},          // jitter below range
+		{"/jsonl?jitter=1.5", http.StatusBadRequest},           // jitter above range
+		{"/jsonl?jitter=abc", http.StatusBadRequest},           // jitter not a number
+	}
+	for _, test := range badTests {
+		t.Run("bad"+test.url, func(t *testing.T) {
+			t.Parallel()
+			req := newTestRequest(t, "GET", app.URL(test.url), nil)
+			resp := mustDoRequest(t, app, req)
+			assert.StatusCode(t, resp, test.code)
+		})
+	}
+
+	t.Run("writes are actually incremental", func(t *testing.T) {
+		t.Parallel()
+
+		var (
+			duration = 100 * time.Millisecond
+			count    = 3
+			endpoint = fmt.Sprintf("/jsonl?duration=%s&count=%d", duration, count)
+
+			wantPauseBetweenWrites = duration / time.Duration(count-1)
+		)
+
+		synctest.Test(t, func(t *testing.T) {
+			app := setupSynctestApp(t)
+			req := newTestRequest(t, "GET", app.URL(endpoint), nil)
+			resp := mustDoRequest(t, app, req)
+			scanner := bufio.NewScanner(resp.Body)
+			lineCount := 0
+
+			for i := 0; ; i++ {
+				start := time.Now()
+				if !scanner.Scan() {
+					break
+				}
+				gotPause := time.Since(start)
+
+				var sr streamResponse
+				err := json.Unmarshal(scanner.Bytes(), &sr)
+				assert.NilError(t, err)
+				assert.Equal(t, sr.ID, i, "unexpected JSONL line ID")
+
+				if i > 0 {
+					assert.Equal(t, gotPause, wantPauseBetweenWrites, "incorrect pause between writes")
+				}
+
+				lineCount++
+			}
+			assert.NilError(t, scanner.Err())
+			assert.Equal(t, lineCount, count, "unexpected number of lines")
+		})
+	})
+
+	t.Run("handle cancelation during initial delay", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, cancel := context.WithTimeout(context.Background(), 25*time.Millisecond)
+		defer cancel()
+
+		req := newTestRequest(t, "GET", app.URL("/jsonl?duration=500ms&delay=500ms"), nil).WithContext(ctx)
+		if _, err := app.Client.Do(req); !os.IsTimeout(err) {
+			t.Fatalf("expected timeout error, got %s", err)
+		}
+	})
+
+	t.Run("handle cancelation during stream", func(t *testing.T) {
+		t.Parallel()
+
+		synctest.Test(t, func(t *testing.T) {
+			app := setupSynctestApp(t)
+
+			ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+			defer cancel()
+
+			req := newTestRequest(t, "GET", app.URL("/jsonl?duration=900ms&delay=0&count=2"), nil).WithContext(ctx)
+			resp := mustDoRequest(t, app, req)
+
+			assert.StatusCode(t, resp, http.StatusOK)
+
+			// Should time out while trying to read the whole body
+			body, err := io.ReadAll(resp.Body)
+			if !os.IsTimeout(err) {
+				t.Fatalf("expected timeout reading body, got %s", err)
+			}
+
+			// Partial read should include the first line
+			var sr streamResponse
+			scanner := bufio.NewScanner(bytes.NewReader(body))
+			if !scanner.Scan() {
+				t.Fatal("expected at least one JSONL line in partial body")
+			}
+			assert.NilError(t, json.Unmarshal(scanner.Bytes(), &sr))
+			assert.Equal(t, sr.ID, 0, "unexpected JSONL line ID")
+		})
+	})
+
+	t.Run("ensure HEAD request works with streaming responses", func(t *testing.T) {
+		t.Parallel()
+		req := newTestRequest(t, "HEAD", app.URL("/jsonl?duration=900ms&delay=100ms"), nil)
+		resp := mustDoRequest(t, app, req)
+		assert.StatusCode(t, resp, http.StatusOK)
+		assert.BodySize(t, resp, 0)
+	})
+}
+
 func TestBearer(t *testing.T) {
 	t.Parallel()
 	app := setupTestApp(t)
@@ -3450,6 +3639,10 @@ func TestSSE(t *testing.T) {
 
 		{url.Values{"duration": {"250ms"}, "delay": {"250ms"}}, 500 * time.Millisecond, 10},
 		{url.Values{"duration": {"250ms"}, "delay": {"0.25s"}}, 500 * time.Millisecond, 10},
+
+		{url.Values{"duration": {"250ms"}, "jitter": {"0"}}, 250 * time.Millisecond, 10},
+		{url.Values{"duration": {"250ms"}, "jitter": {"0.5"}}, 0, 10},
+		{url.Values{"duration": {"250ms"}, "jitter": {"1"}}, 0, 10},
 	}
 	for _, test := range okTests {
 		t.Run(fmt.Sprintf("ok/%s", test.params.Encode()), func(t *testing.T) {
@@ -3495,6 +3688,10 @@ func TestSSE(t *testing.T) {
 		{url.Values{"count": {"-1"}}, http.StatusBadRequest},
 		{url.Values{"count": {"0xff"}}, http.StatusBadRequest},
 		{url.Values{"count": {fmt.Sprintf("%d", app.App.maxSSECount+1)}}, http.StatusBadRequest},
+
+		{url.Values{"jitter": {"-0.1"}}, http.StatusBadRequest},
+		{url.Values{"jitter": {"1.5"}}, http.StatusBadRequest},
+		{url.Values{"jitter": {"abc"}}, http.StatusBadRequest},
 
 		// request would take too long
 		{url.Values{"duration": {"750ms"}, "delay": {"500ms"}}, http.StatusBadRequest},

--- a/httpbin/helpers.go
+++ b/httpbin/helpers.go
@@ -2,6 +2,7 @@ package httpbin
 
 import (
 	"bytes"
+	"context"
 	crypto_rand "crypto/rand"
 	"crypto/sha1"
 	"encoding/base64"
@@ -327,6 +328,45 @@ func computePausePerWrite(duration time.Duration, count int64) time.Duration {
 		pause = (duration + n - 1) / n
 	}
 	return pause
+}
+
+// newPacer returns a channel that emits indices 0..count-1, waiting pause
+// (with jitter) between each. The channel closes when all indices are sent
+// or ctx is cancelled.
+func newPacer(ctx context.Context, count int, pause time.Duration, jitter float64) <-chan int {
+	ch := make(chan int)
+	go func() {
+		defer close(ch)
+		for i := 0; i < count; i++ {
+			if i > 0 && pause > 0 {
+				select {
+				case <-time.After(applyJitter(pause, jitter)):
+				case <-ctx.Done():
+					return
+				}
+			}
+			select {
+			case ch <- i:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+	return ch
+}
+
+// applyJitter randomizes a duration by +/- jitter fraction.
+// jitter must be in [0, 1]; 0 returns d unchanged.
+func applyJitter(d time.Duration, jitter float64) time.Duration {
+	if jitter <= 0 {
+		return d
+	}
+	scale := 1.0 + jitter*(2*rand.Float64()-1)
+	j := time.Duration(float64(d) * scale)
+	if j < 0 {
+		return 0
+	}
+	return j
 }
 
 // syntheticByteStream implements the ReadSeeker interface to allow reading

--- a/httpbin/httpbin.go
+++ b/httpbin/httpbin.go
@@ -24,6 +24,11 @@ type DefaultParams struct {
 	SSECount    int
 	SSEDuration time.Duration
 	SSEDelay    time.Duration
+
+	// for the /jsonl endpoint
+	JSONLCount    int
+	JSONLDuration time.Duration
+	JSONLDelay    time.Duration
 }
 
 // DefaultDefaultParams defines the DefaultParams that are used by default. In
@@ -32,9 +37,14 @@ var DefaultDefaultParams = DefaultParams{
 	DripDuration: 2 * time.Second,
 	DripDelay:    2 * time.Second,
 	DripNumBytes: 10,
-	SSECount:     10,
-	SSEDuration:  5 * time.Second,
-	SSEDelay:     0,
+
+	SSECount:    10,
+	SSEDuration: 5 * time.Second,
+	SSEDelay:    0,
+
+	JSONLCount:    10,
+	JSONLDuration: 0,
+	JSONLDelay:    0,
 }
 
 type headersProcessorFunc func(h http.Header) http.Header
@@ -96,6 +106,10 @@ type HTTPBin struct {
 	// Max number of SSE events to send, based on rough estimate of single
 	// event's size
 	maxSSECount int64
+
+	// Max number of JSONL lines to send, based on rough estimate of single
+	// line's size
+	maxJSONLCount int64
 }
 
 // New creates a new HTTPBin instance
@@ -121,6 +135,11 @@ func New(opts ...OptionFunc) *HTTPBin {
 	var buf bytes.Buffer
 	writeServerSentEvent(&buf, 999, time.Now())
 	h.maxSSECount = h.MaxBodySize / int64(buf.Len())
+
+	// compute max JSONL line count the same way
+	buf.Reset()
+	writeJSONLSample(&buf)
+	h.maxJSONLCount = h.MaxBodySize / int64(buf.Len())
 
 	h.handler = h.Handler()
 	return h
@@ -182,6 +201,7 @@ func (h *HTTPBin) Handler() http.Handler {
 	mux.HandleFunc("/image/{kind}", h.Image)
 	mux.HandleFunc("/ip", h.IP)
 	mux.HandleFunc("/json", h.JSON)
+	mux.HandleFunc("/jsonl", h.JSONL)
 	mux.HandleFunc("/links/{numLinks}", h.Links)
 	mux.HandleFunc("/links/{numLinks}/{offset}", h.Links)
 	mux.HandleFunc("/range/{numBytes}", h.Range)

--- a/httpbin/responses.go
+++ b/httpbin/responses.go
@@ -9,6 +9,7 @@ const (
 	binaryContentType = "application/octet-stream"
 	htmlContentType   = "text/html; charset=utf-8"
 	jsonContentType   = "application/json; charset=utf-8"
+	jsonlContentType  = "application/x-ndjson; charset=utf-8"
 	sseContentType    = "text/event-stream; charset=utf-8"
 	textContentType   = "text/plain; charset=utf-8"
 )

--- a/httpbin/static/index.html.tmpl
+++ b/httpbin/static/index.html.tmpl
@@ -99,6 +99,7 @@
 <li><a href="{{.Prefix}}/image/webp"><code>{{.Prefix}}/image/webp</code></a> Returns a WEBP image.</li>
 <li><a href="{{.Prefix}}/ip"><code>{{.Prefix}}/ip</code></a> Returns Origin IP.</li>
 <li><a href="{{.Prefix}}/json"><code>{{.Prefix}}/json</code></a> Returns JSON.</li>
+<li><a href="{{.Prefix}}/jsonl?count=10&amp;duration=5s&amp;delay=1s&amp;jitter=0.5"><code>{{.Prefix}}/jsonl?count=10&amp;duration=5s&amp;delay=1s&amp;jitter=0.5</code></a> Streams <em>count</em> lines of JSON Lines data over an optional <em>duration</em> after an optional initial <em>delay</em>, with optional <em>jitter</em> (0-1) to randomize timing between lines.</li>
 <li><a href="{{.Prefix}}/links/10"><code>{{.Prefix}}/links/:n</code></a> Returns page containing <em>n</em> HTML links.</li>
 <li><code>{{.Prefix}}/patch</code> Returns request data.  Allows only <code>PATCH</code> requests.</li>
 <li><code>{{.Prefix}}/post</code> Returns request data.  Allows only <code>POST</code> requests.</li>

--- a/httpbin/static/index.html.tmpl
+++ b/httpbin/static/index.html.tmpl
@@ -99,7 +99,7 @@
 <li><a href="{{.Prefix}}/image/webp"><code>{{.Prefix}}/image/webp</code></a> Returns a WEBP image.</li>
 <li><a href="{{.Prefix}}/ip"><code>{{.Prefix}}/ip</code></a> Returns Origin IP.</li>
 <li><a href="{{.Prefix}}/json"><code>{{.Prefix}}/json</code></a> Returns JSON.</li>
-<li><a href="{{.Prefix}}/jsonl?count=10&amp;duration=5s&amp;delay=1s&amp;jitter=0.5"><code>{{.Prefix}}/jsonl?count=10&amp;duration=5s&amp;delay=1s&amp;jitter=0.5</code></a> Streams <em>count</em> lines of JSON Lines data over an optional <em>duration</em> after an optional initial <em>delay</em>, with optional <em>jitter</em> (0-1) to randomize timing between lines.</li>
+<li><a href="{{.Prefix}}/jsonl?count=10&amp;duration=5s&amp;delay=1s&amp;jitter=0.5"><code>{{.Prefix}}/jsonl?count=10&amp;duration=5s&amp;delay=1s&amp;jitter=0.5</code></a> Streams <em>count</em> lines of <a href="https://jsonlines.org/">JSON Lines</a> data over an optional <em>duration</em> after an optional initial <em>delay</em>, with optional <em>jitter</em> ratio (0.0-1.0) to randomize timing between lines.</li>
 <li><a href="{{.Prefix}}/links/10"><code>{{.Prefix}}/links/:n</code></a> Returns page containing <em>n</em> HTML links.</li>
 <li><code>{{.Prefix}}/patch</code> Returns request data.  Allows only <code>PATCH</code> requests.</li>
 <li><code>{{.Prefix}}/post</code> Returns request data.  Allows only <code>POST</code> requests.</li>


### PR DESCRIPTION
Adds /jsonl endpoint, extracts shared pacing/timing functionality to be reused by /sse. /sse gains jitter ability too