### PR TITLE
ci: updated release process

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,75 +1,94 @@
-# This action pushes new amd64 and arm64 docker images to the Docker and GitHub
-# registries on every new release of the project.
+# The release workflow is triggered by the creation of a GitHub release and
+# builds cross-platform binaries and multi-arch docker images.
 #
-# Cobbled together from these sources:
-# - https://github.com/docker/build-push-action/#usage
-# - https://docs.github.com/en/actions/publishing-packages/publishing-docker-images
-
+# For each build artifact, build provenance metadata is generated, signed,
+# attested, etc.
 name: release
 
 "on":
   release:
     types: [published]
-
-  # we do not build and push images for every commit, only for tagged releases.
-  # uncomment this to enablle building for pull requests, to debug this
-  # workflow.
-  #
+  # Uncomment to test the workflow on pull requests
   # pull_request:
   #   branches: [main]
 
+permissions:
+  contents: read
+
+# Serialize release workflows without canceling, on the off chance we need to
+# trigger a quick follow-up release while one is still in progress.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
-  docker:
+  release:
+    name: release
     runs-on: ubuntu-latest
-
     permissions:
-      contents: read
-      packages: write
-
+      contents: write      # publish GitHub release and upload release artifacts
+      packages: write      # push OCI images to ghcr.io
+      id-token: write      # request OIDC token for Sigstore signing
+      attestations: write  # publish attestations to GitHub attestation store
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
-      - uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
-
-      - uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          persist-credentials: false
+          fetch-depth: 0
+
+      - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
+        with:
+          go-version: 'stable'
+          # caching explicitly disabled in release workflows
+          # https://docs.zizmor.sh/audits/#cache-poisoning
+          cache: false
+      - uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+      - uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
+      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+      - uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29 # v7.0.0
+        with:
+          version: '~> v2'
+          install-only: true
+
+      - uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
+        with:
+          username: ${{ github.repository_owner }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+      - uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
-        id: meta
+      - name: "Run make release"
         env:
-          # https://docs.docker.com/build/ci/github-actions/annotations/#configure-annotation-level
-          DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index
-        with:
-          images: |
-            mccutchen/go-httpbin
-            ghcr.io/${{ github.repository }}
-          tags: |
-            # For releases, use the standard tags and special "latest" tag
-            type=semver,pattern={{version}},enable=${{ github.event_name == 'release' }}
-            type=semver,pattern={{major}}.{{minor}},enable=${{ github.event_name == 'release' }}
-            type=raw,value=latest,enable=${{ github.event_name == 'release' }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          QUILL_NOTARY_ISSUER: ${{ secrets.QUILL_NOTARY_ISSUER }}
+          QUILL_NOTARY_KEY: ${{ secrets.QUILL_NOTARY_KEY }}
+          QUILL_NOTARY_KEY_ID: ${{ secrets.QUILL_NOTARY_KEY_ID }}
+          QUILL_SIGN_P12: ${{ secrets.QUILL_SIGN_P12 }}
+          QUILL_SIGN_PASSWORD: ${{ secrets.QUILL_SIGN_PASSWORD }}
+          # On pull requests, we run `make release-dry-run` and on actual
+          # releases we run `make release`
+          RELEASE_TARGET: ${{ github.event_name == 'pull_request' && 'release-dry-run' || 'release' }}
+        run:
+          # Note that we override the CMD_GORELEASER var to use the binary
+          # installed by the goreleaser/goreleaser-action step above instead
+          # of using the Makefile's default `go run ...` approach because it
+          # takes a long time to build goreleaser itself.
+          make "${RELEASE_TARGET}" GORELEASER="goreleaser"
 
-            # For pull requests, use the commit SHA
-            #
-            # Note that this is disabled by default, but can be enabled for
-            # debugging purposes by uncommenting the pull_request trigger at
-            # top of the workflow.
-            type=sha,format=short,enable=${{ github.event_name == 'pull_request' }}
-
-      - uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          platforms: linux/amd64,linux/arm64
-          push: true
-          sbom: true
-          provenance: mode=max
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          annotations: ${{ steps.meta.outputs.annotations }}
+          name: goreleaser-artifacts
+          path: dist/artifacts.json
+
+      - uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
+        with:
+          subject-checksums: ./dist/checksums.txt
+
+      - uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
+        with:
+          subject-checksums: ./dist/digests.txt
+          push-to-registry: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,8 +9,8 @@ name: release
   release:
     types: [published]
   # Uncomment to test the workflow on pull requests
-  # pull_request:
-  #   branches: [main]
+  pull_request:
+    branches: [main]
 
 permissions:
   contents: read

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,120 @@
+version: 2
+
+# sort tags by date, so that a final release tag will be chosen over a
+# pre-release tag when they point to the same commit.
+git:
+  tag_sort: "-creatordate"
+
+builds:
+  - env:
+      - CGO_ENABLED=0
+    goos:
+      - darwin
+      - linux
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    mod_timestamp: "{{ .CommitTimestamp }}"
+    flags:
+      - -trimpath
+    ldflags:
+      - -s -w -X main.version={{.Version}} -X main.commit={{.ShortCommit}} -X main.buildDate={{.Date}}
+
+# replace per-arch macos binaries with a single universal binary
+universal_binaries:
+  - replace: true
+
+source:
+  enabled: true
+
+sboms:
+  - id: archive
+    artifacts: archive
+  - id: source
+    artifacts: source
+
+archives:
+  - name_template: >-
+      {{ .ProjectName }}-
+      {{- .Os | tolower }}-
+      {{- .Arch }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
+    formats:
+      - tar.gz
+    format_overrides:
+      - goos: windows
+        formats:
+          - zip
+
+checksum:
+  name_template: 'checksums.txt'
+
+snapshot:
+  version_template: "{{ incpatch .Version }}-next"
+
+release:
+  draft: false
+  prerelease: auto
+  mode: replace
+
+dockers_v2:
+  - images:
+      - index.docker.io/mccutchen/go-app-template
+      - ghcr.io/mccutchen/go-app-template
+    tags:
+      - "{{.Version}}"
+      - '{{ if not .Prerelease }}{{.Major}}.{{.Minor}}{{ end }}'
+      - '{{ if not .Prerelease }}latest{{ end }}'
+    platforms:
+      - linux/amd64
+      - linux/arm64
+    dockerfile: Dockerfile.release
+    sbom: true
+    labels:
+      org.opencontainers.image.created: "{{.Date}}"
+      org.opencontainers.image.revision: "{{.FullCommit}}"
+      org.opencontainers.image.version: "{{.Version}}"
+      org.opencontainers.image.source: "{{.GitURL}}"
+      org.opencontainers.image.url: "{{.GitURL}}"
+      org.opencontainers.image.title: "{{.ProjectName}}"
+      org.opencontainers.image.licenses: MIT
+    annotations:
+      org.opencontainers.image.created: "{{.Date}}"
+      org.opencontainers.image.revision: "{{.FullCommit}}"
+      org.opencontainers.image.version: "{{.Version}}"
+      org.opencontainers.image.source: "{{.GitURL}}"
+      org.opencontainers.image.url: "{{.GitURL}}"
+      org.opencontainers.image.title: "{{.ProjectName}}"
+      org.opencontainers.image.licenses: MIT
+
+docker_signs:
+  - cmd: cosign
+    args:
+      - sign
+      - --yes
+      - "${artifact}@${digest}"
+    # '' is for images built by dockers_v2, per the docs:
+    # https://goreleaser.com/customization/sign/docker_sign/
+    artifacts: ''
+
+notarize:
+  macos:
+    - enabled: '{{ isEnvSet "QUILL_SIGN_P12" }}'
+      sign:
+        certificate: "{{.Env.QUILL_SIGN_P12}}"
+        password: "{{.Env.QUILL_SIGN_PASSWORD}}"
+      notarize:
+        issuer_id: "{{.Env.QUILL_NOTARY_ISSUER}}"
+        key_id: "{{.Env.QUILL_NOTARY_KEY_ID}}"
+        key: "{{.Env.QUILL_NOTARY_KEY}}"
+        wait: true
+        # Apple rejects JWTs with ttl > 20m, quill sets token lifetime to
+        # this timeout + 2m.
+        timeout: 18m
+
+changelog:
+  disable: true
+
+announce:
+  skip: true

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -6,8 +6,7 @@ git:
   tag_sort: "-creatordate"
 
 builds:
-  - env:
-      - CGO_ENABLED=0
+  - main: ./...
     goos:
       - darwin
       - linux
@@ -15,11 +14,13 @@ builds:
     goarch:
       - amd64
       - arm64
-    mod_timestamp: "{{ .CommitTimestamp }}"
+    env:
+      - CGO_ENABLED=0
     flags:
       - -trimpath
     ldflags:
       - -s -w -X main.version={{.Version}} -X main.commit={{.ShortCommit}} -X main.buildDate={{.Date}}
+    mod_timestamp: "{{ .CommitTimestamp }}"
 
 # replace per-arch macos binaries with a single universal binary
 universal_binaries:

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,0 +1,13 @@
+# This Dockerfile is used by goreleaser to build multi-arch OCI images. It is
+# not meant to be built manually via e.g. `docker build`.
+#
+# The binaries are first cross-compiled on the host machine by goreleaser and
+# then copied into the image directly. See the [Docker build context][1]
+# section of goreleaser dockers_v2 pipeline docs for more info on how this
+# works.
+#
+# [1]: https://goreleaser.com/customization/package/dockers_v2/#the-docker-build-context
+FROM gcr.io/distroless/static:nonroot
+ARG TARGETPLATFORM
+COPY $TARGETPLATFORM/go-httpbin /usr/bin/
+ENTRYPOINT ["/usr/bin/go-httpbin"]

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,3 @@
-# The version that will be used in docker tags (e.g. to push a
-# go-httpbin:latest image use `make imagepush VERSION=latest)`
-VERSION    ?= $(shell git rev-parse --short HEAD)
-DOCKER_TAG ?= mccutchen/go-httpbin:$(VERSION)
-
 # Built binaries will be placed here
 DIST_PATH  	  ?= dist
 
@@ -12,10 +7,11 @@ COVERAGE_ARGS ?= -covermode=atomic -coverprofile=$(COVERAGE_PATH)
 TEST_ARGS     ?= -race
 
 # 3rd party tools
-FMT         := go run mvdan.cc/gofumpt@v0.7.0
-LINT        := go run github.com/mgechev/revive@v1.7.0
-REFLEX      := go run github.com/cespare/reflex@v0.3.1
-STATICCHECK := go run honnef.co/go/tools/cmd/staticcheck@2025.1.1
+GOFUMPT     := go run mvdan.cc/gofumpt@v0.9.2
+GORELEASER  := go run github.com/goreleaser/goreleaser/v2@v2.15.2
+REFLEX      := go run github.com/cespare/reflex@v0.3.2
+REVIVE      := go run github.com/mgechev/revive@v1.15.0
+STATICCHECK := go run honnef.co/go/tools/cmd/staticcheck@2026.1
 
 # Host and port to use when running locally via `make run` or `make watch`
 HOST ?= 127.0.0.1
@@ -44,7 +40,7 @@ clean:
 
 
 # =============================================================================
-# test & lint
+# test
 # =============================================================================
 test:
 	go test $(TEST_ARGS) ./...
@@ -66,12 +62,20 @@ testautobahn:
 	AUTOBAHN_TESTS=1 AUTOBAHN_OPEN_REPORT=1 go test -v -run ^TestWebSocketServer$$ $(TEST_ARGS) ./...
 .PHONY: autobahntests
 
+
+# ===========================================================================
+# linting/formatting
+# ===========================================================================
 lint:
-	test -z "$$($(FMT) -d -e .)" || (echo "Error: $(FMT) failed"; $(FMT) -d -e . ; exit 1)
+	$(GOFUMPT) -d .
 	go vet ./...
-	$(LINT) -set_exit_status ./...
+	$(REVIVE) -set_exit_status ./...
 	$(STATICCHECK) ./...
 .PHONY: lint
+
+fmt:
+	$(GOFUMPT) -w .
+.PHONY: fmt
 
 
 # =============================================================================
@@ -86,16 +90,31 @@ watch:
 .PHONY: watch
 
 
-# =============================================================================
-# docker images
-# =============================================================================
-image:
-	DOCKER_BUILDKIT=1 docker build -t $(DOCKER_TAG) .
-.PHONY: image
+# ===========================================================================
+# Release
+# ===========================================================================
+#
+# Note: Releases are built automatically via the release.yaml GitHub Actions
+# workflow when a new release is create via the GitHub UI.
+#
+# The release target requires valid values for these env vars:
+#
+#   QUILL_SIGN_P12
+#   QUILL_SIGN_PASSWORD
+#   QUILL_NOTARY_ISSUER
+#   QUILL_NOTARY_KEY_ID
+#   QUILL_NOTARY_KEY
+#
+# See quill's usage docs[1] and goreleaser's macOS notarization docs[2] for
+# more info about these values and how to generate them.
+#
+# [1]: https://github.com/anchore/quill/blob/main/README.md#usage
+# [2]: https://goreleaser.com/customization/notarize/
+# ===========================================================================
+release: clean
+	$(GORELEASER) release --clean --verbose
+.PHONY: release
 
-imagepush:
-	docker buildx create --name httpbin
-	docker buildx use httpbin
-	docker buildx build --push --platform linux/amd64,linux/arm64 -t $(DOCKER_TAG) .
-	docker buildx rm httpbin
-.PHONY: imagepush
+release-dry-run: clean
+	$(GORELEASER) release --clean --verbose --snapshot
+.PHONY: release-dry-run

--- a/cmd/go-httpbin/main.go
+++ b/cmd/go-httpbin/main.go
@@ -3,10 +3,25 @@ package main
 
 import (
 	"os"
+	"time"
 
 	"github.com/mccutchen/go-httpbin/v2/httpbin/cmd"
 )
 
+// Build metadata, populated by the release process (see .goreleaser.yaml).
+var (
+	version   = "dev"
+	commit    = "HEAD"
+	buildDate = time.Now().String()
+)
+
 func main() {
+	// TODO: incorporate into a `--version` flag.
+	{
+		_ = version
+		_ = commit
+		_ = buildDate
+	}
+
 	os.Exit(cmd.Main())
 }

--- a/httpbin/handlers_test.go
+++ b/httpbin/handlers_test.go
@@ -3286,18 +3286,18 @@ func TestJSONL(t *testing.T) {
 		url           string
 		expectedLines int
 	}{
-		{"/jsonl", 10},                                          // default count
-		{"/jsonl?count=1", 1},                                   // minimum
-		{"/jsonl?count=5", 5},                                   // custom count
-		{"/jsonl?count=0", 1},                                   // clamped to min
-		{"/jsonl?count=-5", 1},                                  // clamped to min
-		{"/jsonl?count=3&duration=1s", 3},                       // with duration
-		{"/jsonl?count=1&duration=1s", 1},                       // single line with duration
-		{"/jsonl?count=3&delay=0s", 3},                          // with zero delay
-		{"/jsonl?count=2&duration=1s&delay=0s", 2},              // with both
-		{"/jsonl?count=3&duration=1s&jitter=0", 3},              // jitter=0 (no effect)
-		{"/jsonl?count=3&duration=1s&jitter=0.5", 3},            // jitter=0.5
-		{"/jsonl?count=3&duration=1s&jitter=1", 3},              // jitter=1 (max)
+		{"/jsonl", 10},                               // default count
+		{"/jsonl?count=1", 1},                        // minimum
+		{"/jsonl?count=5", 5},                        // custom count
+		{"/jsonl?count=0", 1},                        // clamped to min
+		{"/jsonl?count=-5", 1},                       // clamped to min
+		{"/jsonl?count=3&duration=1s", 3},            // with duration
+		{"/jsonl?count=1&duration=1s", 1},            // single line with duration
+		{"/jsonl?count=3&delay=0s", 3},               // with zero delay
+		{"/jsonl?count=2&duration=1s&delay=0s", 2},   // with both
+		{"/jsonl?count=3&duration=1s&jitter=0", 3},   // jitter=0 (no effect)
+		{"/jsonl?count=3&duration=1s&jitter=0.5", 3}, // jitter=0.5
+		{"/jsonl?count=3&duration=1s&jitter=1", 3},   // jitter=1 (max)
 	}
 	for _, test := range okTests {
 		t.Run("ok"+test.url, func(t *testing.T) {
@@ -3887,7 +3887,6 @@ func TestUpload(t *testing.T) {
 				assert.DeepEqual(t, result.BytesReceived, int64(len(test.requestBody)), "BytesReceived should match requestedBody size")
 			})
 		}
-
 	}
 }
 
@@ -3931,7 +3930,7 @@ func TestWebSocketEcho(t *testing.T) {
 		})
 	})
 
-	var maxBodySize = 1024
+	maxBodySize := 1024
 	paramTests := []struct {
 		query      string
 		wantStatus int

--- a/internal/testing/netpipetestserver/netpipetestserver.go
+++ b/internal/testing/netpipetestserver/netpipetestserver.go
@@ -86,7 +86,7 @@ func (ln *netPipeListener) Addr() net.Addr {
 // DialContext creates both client and server conns via [net.Pipe] and
 // returns the client conn. The server conn is enqueued for the listener to
 // pick up in its [Accept] method.
-func (ln *netPipeListener) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
+func (ln *netPipeListener) DialContext(ctx context.Context, _, _ string) (net.Conn, error) {
 	clientConn, serverConn := net.Pipe()
 	select {
 	case ln.connCh <- serverConn:


### PR DESCRIPTION
Switch over to a [goreleaser][] based process, still triggered by the creation of a release on GitHub, which now
- Builds signed OCI images w/ SBOMs and pushes them to GHCR and Dockker Hub (same as before)
- Builds signed release binaries for Linux, Mac (w/ notarization), and Windows on both amd64 and arm64 architectures
- Generates build provenance attestations on GitHub

This closes #209, #242 and #85 (kinda incidentally).  It also lays the ground work for addressing #188 and #190, which will be fixed in follow ups.

My plan is to merge this and create pre-releases while I nail down any loose ends before cutting a final release.

[goreleaser]: https://github.com/goreleaser/goreleaser