### PR TITLE
ci: try specific main path to fix notarization

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -6,7 +6,7 @@ git:
   tag_sort: "-creatordate"
 
 builds:
-  - main: ./...
+  - main: ./cmd/go-httpbin
     goos:
       - darwin
       - linux


### PR DESCRIPTION
For as-yet unknown reasons, the macOS notarization step that seems to have run as part of building https://github.com/mccutchen/go-httpbin/releases/tag/v2.22.0-rc2 yielded binaries that macOS refuses to run.

Throwing stuff at the wall here, let's see what this does.