### PR TITLE
ci: do not overwrite existing release description

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -57,7 +57,7 @@ snapshot:
 release:
   draft: false
   prerelease: auto
-  mode: replace
+  mode: keep-existing
 
 dockers_v2:
   - images:


### PR DESCRIPTION
Do not overwrite existing release text, as seem to have happened on https://github.com/mccutchen/go-httpbin/releases/tag/v2.22.0-rc4 after [this workflow run](https://github.com/mccutchen/go-httpbin/actions/runs/24272635311/job/70880503239).