### PR TITLE
compat: avoid OCI entrypoint change breaking legacy invocations

### DIFF
--- a/httpbin/cmd/cmd.go
+++ b/httpbin/cmd/cmd.go
@@ -55,6 +55,13 @@ func Main(build BuildInfo) int {
 // mainImpl is the real implementation of Main(), extracted for better
 // testability.
 func mainImpl(args []string, build BuildInfo, getEnvVal func(string) string, getEnviron func() []string, getHostname func() (string, error), out io.Writer) int {
+	// Support `docker run <img> go-httpbin -foo -bar` by stripping the binary
+	// name when it appears as the first argument for backwards compatibility
+	// after the OCI image entrypoint changed from sh to go-httpbin itself.
+	if len(args) > 0 && args[0] == "go-httpbin" {
+		args = args[1:]
+	}
+
 	cfg, err := loadConfig(args, getEnvVal, getEnviron, getHostname)
 	if err != nil {
 		if cfgErr, ok := err.(ConfigError); ok {

--- a/httpbin/cmd/cmd_test.go
+++ b/httpbin/cmd/cmd_test.go
@@ -629,6 +629,11 @@ func TestMainImpl(t *testing.T) {
 			wantCode: 0,
 			wantOut:  usage,
 		},
+		"binary name as first arg is stripped for docker compat": {
+			args:     []string{"go-httpbin", "-h"},
+			wantCode: 0,
+			wantOut:  usage,
+		},
 		"version": {
 			build:    BuildInfo{Version: "1.2.3", Commit: "abc123", Date: "1988-11-12T10:00:00Z"},
 			args:     []string{"-version"},


### PR DESCRIPTION
Before #244, the entrypoint for Docker/OCI images was a shell, so it was possible to run go-httpbin like so to pass CLI args:

    docker run mccutchen/go-httpbin go-httpbin -use-real-hostname

After that change, the entrypoint is the go-httpbin binary itself, so the above would become:

    docker run mccutchen/go-httpbin -use-real-hostname

On the off chance there are users who a) rely on the first form and b) also automatically update to the latest image, we can pretty easily add a bit of shim code to allow the old invocation to work in new images.