### PR TITLE
fix(docker): restore missing EXPOSE directive

### DIFF
--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -10,4 +10,5 @@
 FROM gcr.io/distroless/static:nonroot
 ARG TARGETPLATFORM
 COPY $TARGETPLATFORM/go-httpbin /usr/bin/
+EXPOSE 8080
 ENTRYPOINT ["/usr/bin/go-httpbin"]


### PR DESCRIPTION
This fixes a regression introduced in https://github.com/mccutchen/go-httpbin/pull/244, as [reported](https://github.com/mccutchen/go-httpbin/pull/244#issuecomment-4248266342) by @nightah:

> Is there a reason the default port EXPOSE was omitted in the release Dockerfile?
> This has caused issues with Traefik, where it can no longer auto-discover the port for the Docker provider.