### PR TITLE
feat: support text format for /ip

### DIFF
--- a/httpbin/handlers.go
+++ b/httpbin/handlers.go
@@ -170,8 +170,14 @@ func (h *HTTPBin) Deflate(w http.ResponseWriter, r *http.Request) {
 
 // IP echoes the IP address of the incoming request
 func (h *HTTPBin) IP(w http.ResponseWriter, r *http.Request) {
+	origin := getClientIP(r)
+	if r.URL.Query().Get("format") == "text" {
+		writeResponse(w, http.StatusOK, textContentType, []byte(origin))
+		return
+	}
+
 	writeJSON(http.StatusOK, w, &ipResponse{
-		Origin: getClientIP(r),
+		Origin: origin,
 	})
 }
 

--- a/httpbin/handlers_test.go
+++ b/httpbin/handlers_test.go
@@ -432,6 +432,24 @@ func TestIP(t *testing.T) {
 		})
 	}
 
+	t.Run("text format", func(t *testing.T) {
+		t.Parallel()
+
+		// this test does not use a real server, because we need to control
+		// the RemoteAddr field on the request object to make the test
+		// deterministic.
+		app := createApp()
+		w := httptest.NewRecorder()
+
+		req, _ := http.NewRequest("GET", "/ip?format=text", nil)
+		req.RemoteAddr = "192.168.0.100"
+
+		app.ServeHTTP(w, req)
+		assert.Equal(t, w.Code, http.StatusOK, "wrong status code")
+		assert.Equal(t, w.Header().Get("Content-Type"), textContentType, "wrong content type")
+		assert.Equal(t, w.Body.String(), "192.168.0.100", "incorrect body")
+	})
+
 	t.Run("via real connection", func(t *testing.T) {
 		// (*Request).RemoteAddr includes the local port for real incoming TCP
 		// connections but not for direct ServeHTTP calls as the used in the


### PR DESCRIPTION
## Summary

Adds support for `GET /ip?format=text`, returning the detected client IP directly as `text/plain; charset=utf-8`. The default `/ip` response stays unchanged and continues to return `{"origin": ...}` JSON.

Closes #254.

## Testing

- `go test ./httpbin -run 'TestIP/text_format$' -count=1`
- `go test ./httpbin -run 'TestIP/(remote_addr_used_if_no_x-forwarded-for|first_entry_in_x-forwarded-for_used_if_present)$' -count=1`
- `go test ./httpbin -run '^$' -count=1`
- `git diff --check`

Note: `go test ./httpbin -run TestIP -count=1` reaches the existing real-connection subtest and fails in this sandbox because `httptest` cannot listen on localhost (`operation not permitted`).
