### PR TITLE
test: refactor to prep for live integration tests

### DIFF
--- a/httpbin/handlers_test.go
+++ b/httpbin/handlers_test.go
@@ -34,18 +34,49 @@ import (
 // the basis for a mini test "framework" used across the test suite. It
 // comprises
 type appTestInfo struct {
-	// App is the [HTTPBin] instance under test, configured by [createApp].
+	// App is the [HTTPBin] instance under test, configured by [createApp]. It
+	// is nil when the suite runs against a remote target (see TARGET_URL).
 	App *HTTPBin
-	// Srv is an [httptest.Server] running that instance.
+	// Srv is an [httptest.Server] running that instance. It is nil when the
+	// suite runs against a remote target.
 	Srv *httptest.Server
-	// Client is an [http.Client] configured to connect to the test server.
+	// Client is an [http.Client] configured to connect to the target server.
 	Client *http.Client
+	// baseURL is the scheme://host[/prefix] that URL builds upon. Locally this
+	// is Srv.URL; against a remote target it is derived from TARGET_URL.
+	baseURL string
+	// cfg captures the target's configuration (limits, prefix, etc.) so tests
+	// can assert behavior without reaching into the in-process [HTTPBin].
+	cfg targetConfig
+}
+
+// targetConfig captures the configuration values tests need to know about the
+// server under test. Locally these are read from the constructed [HTTPBin];
+// against a remote target they are derived from the same environment
+// variables used to configure the deployment (see [configFromEnv]).
+type targetConfig struct {
+	Prefix        string
+	MaxBodySize   int64
+	MaxDuration   time.Duration
+	MaxSSECount   int64
+	MaxJSONLCount int64
+}
+
+// configFromApp builds a [targetConfig] from an in-process [HTTPBin].
+func configFromApp(app *HTTPBin) targetConfig {
+	return targetConfig{
+		Prefix:        app.prefix,
+		MaxBodySize:   app.MaxBodySize,
+		MaxDuration:   app.MaxDuration,
+		MaxSSECount:   app.maxSSECount,
+		MaxJSONLCount: app.maxJSONLCount,
+	}
 }
 
 // URL generates the full URL for the given path and optional query params,
-// pointing at the current test server.
+// pointing at the current target server.
 func (appT *appTestInfo) URL(path string, params ...url.Values) string {
-	u := appT.Srv.URL + path
+	u := appT.baseURL + path
 	for i, p := range params {
 		if i == 0 && p != nil { // ignore nil params always passed through by some helpers (e.g. doGetRequest)
 			u += "?"
@@ -72,9 +103,11 @@ func setupTestApp(t *testing.T, opts ...OptionFunc) *appTestInfo {
 	}
 
 	return &appTestInfo{
-		App:    app,
-		Srv:    srv,
-		Client: client,
+		App:     app,
+		Srv:     srv,
+		Client:  client,
+		baseURL: srv.URL,
+		cfg:     configFromApp(app),
 	}
 }
 
@@ -1030,7 +1063,7 @@ func testRequestWithBodyInvalidJSON(t *testing.T, app *appTestInfo, verb, path s
 }
 
 func testRequestWithBodyBodyTooBig(t *testing.T, app *appTestInfo, verb, path string) {
-	body := make([]byte, app.App.MaxBodySize+1)
+	body := make([]byte, app.cfg.MaxBodySize+1)
 	req := newTestRequest(t, verb, app.URL(path), bytes.NewReader(body))
 	resp := mustDoRequest(t, app, req)
 	assert.StatusCode(t, resp, http.StatusBadRequest)
@@ -2582,7 +2615,7 @@ func TestRange(t *testing.T) {
 	t.Run("ok_no_range", func(t *testing.T) {
 		t.Parallel()
 
-		wantBytes := app.App.MaxBodySize - 1
+		wantBytes := app.cfg.MaxBodySize - 1
 		url := fmt.Sprintf("/range/%d", wantBytes)
 		req := newTestRequest(t, "GET", app.URL(url), nil)
 
@@ -3332,7 +3365,7 @@ func TestBase64(t *testing.T) {
 			"decode failed",
 		},
 		{
-			"/base64/decode/" + strings.Repeat("X", int(app.App.MaxBodySize)+1),
+			"/base64/decode/" + strings.Repeat("X", int(app.cfg.MaxBodySize)+1),
 			http.StatusBadRequest,
 			"input data exceeds max length",
 		},
@@ -3444,7 +3477,7 @@ func TestJSONL(t *testing.T) {
 
 	t.Run("ok/count clamped to max", func(t *testing.T) {
 		t.Parallel()
-		maxCount := int(app.App.maxJSONLCount)
+		maxCount := int(app.cfg.MaxJSONLCount)
 		url := fmt.Sprintf("/jsonl?count=%d", maxCount+500)
 		req := newTestRequest(t, "GET", app.URL(url), nil)
 		resp := mustDoRequest(t, app, req)
@@ -3777,7 +3810,7 @@ func TestSSE(t *testing.T) {
 
 		{url.Values{"count": {"1"}}, 0, 1},
 		{url.Values{"count": {"011"}}, 0, 11},
-		{url.Values{"count": {fmt.Sprintf("%d", app.App.maxSSECount)}}, 0, int(app.App.maxSSECount)},
+		{url.Values{"count": {fmt.Sprintf("%d", app.cfg.MaxSSECount)}}, 0, int(app.cfg.MaxSSECount)},
 
 		{url.Values{"duration": {"100ms"}, "delay": {"100ms"}}, 200 * time.Millisecond, 10},
 		{url.Values{"duration": {"100ms"}, "delay": {"0.1"}}, 200 * time.Millisecond, 10},
@@ -3827,7 +3860,7 @@ func TestSSE(t *testing.T) {
 		{url.Values{"count": {"0"}}, http.StatusBadRequest},
 		{url.Values{"count": {"-1"}}, http.StatusBadRequest},
 		{url.Values{"count": {"0xff"}}, http.StatusBadRequest},
-		{url.Values{"count": {fmt.Sprintf("%d", app.App.maxSSECount+1)}}, http.StatusBadRequest},
+		{url.Values{"count": {fmt.Sprintf("%d", app.cfg.MaxSSECount+1)}}, http.StatusBadRequest},
 
 		{url.Values{"jitter": {"-0.1"}}, http.StatusBadRequest},
 		{url.Values{"jitter": {"1.5"}}, http.StatusBadRequest},

--- a/httpbin/handlers_test.go
+++ b/httpbin/handlers_test.go
@@ -34,26 +34,20 @@ import (
 // the basis for a mini test "framework" used across the test suite. It
 // comprises
 type appTestInfo struct {
-	// App is the [HTTPBin] instance under test, configured by [createApp]. It
-	// is nil when the suite runs against a remote target (see TARGET_URL).
+	// App is the [HTTPBin] instance under test, configured by [createApp].
 	App *HTTPBin
-	// Srv is an [httptest.Server] running that instance. It is nil when the
-	// suite runs against a remote target.
+	// Srv is an [httptest.Server] running that instance.
 	Srv *httptest.Server
 	// Client is an [http.Client] configured to connect to the target server.
 	Client *http.Client
-	// baseURL is the scheme://host[/prefix] that URL builds upon. Locally this
-	// is Srv.URL; against a remote target it is derived from TARGET_URL.
+	// baseURL is the URL for the instance under test (i.e. Srv.URL).
 	baseURL string
-	// cfg captures the target's configuration (limits, prefix, etc.) so tests
-	// can assert behavior without reaching into the in-process [HTTPBin].
+	// cfg represents the configuration for the server under test.
 	cfg targetConfig
 }
 
 // targetConfig captures the configuration values tests need to know about the
-// server under test. Locally these are read from the constructed [HTTPBin];
-// against a remote target they are derived from the same environment
-// variables used to configure the deployment (see [configFromEnv]).
+// server under test.
 type targetConfig struct {
 	Prefix        string
 	MaxBodySize   int64
@@ -1749,8 +1743,8 @@ func TestCookies(t *testing.T) {
 					wantHttpOnly: true, wantPath: "/custom",
 				},
 				"attr[Domain]=example.com": {
-					params:       url.Values{"k": {"v"}, "attr[Domain]": {"example.com"}},
-					wantDomain:   "example.com", wantHttpOnly: true, wantPath: "/",
+					params:     url.Values{"k": {"v"}, "attr[Domain]": {"example.com"}},
+					wantDomain: "example.com", wantHttpOnly: true, wantPath: "/",
 				},
 				"attr[SameSite]=strict": {
 					params:       url.Values{"k": {"v"}, "attr[SameSite]": {"strict"}},
@@ -1769,8 +1763,8 @@ func TestCookies(t *testing.T) {
 					wantHttpOnly: true, wantPath: "/",
 				},
 				"attr names are case-insensitive": {
-					params:       url.Values{"k": {"v"}, "attr[secure]": {"true"}, "attr[httponly]": {"false"}, "attr[path]": {"/x"}, "attr[DOMAIN]": {"a.com"}, "attr[SameSite]": {"Lax"}},
-					wantDomain:   "a.com", wantHttpOnly: false, wantPath: "/x", wantSameSite: http.SameSiteLaxMode, wantSecure: true,
+					params:     url.Values{"k": {"v"}, "attr[secure]": {"true"}, "attr[httponly]": {"false"}, "attr[path]": {"/x"}, "attr[DOMAIN]": {"a.com"}, "attr[SameSite]": {"Lax"}},
+					wantDomain: "a.com", wantHttpOnly: false, wantPath: "/x", wantSameSite: http.SameSiteLaxMode, wantSecure: true,
 				},
 			}
 
@@ -1832,8 +1826,8 @@ func TestCookies(t *testing.T) {
 					wantHttpOnly: true, wantPath: "/", wantSecure: false,
 				},
 				"attr[Domain]=example.com": {
-					params:       url.Values{"k2": {""}, "attr[Domain]": {"example.com"}},
-					wantDomain:   "example.com", wantHttpOnly: true, wantPath: "/",
+					params:     url.Values{"k2": {""}, "attr[Domain]": {"example.com"}},
+					wantDomain: "example.com", wantHttpOnly: true, wantPath: "/",
 				},
 				"attr[Path]=/custom": {
 					params:       url.Values{"k2": {""}, "attr[Path]": {"/custom"}},


### PR DESCRIPTION
Step one for implementing https://github.com/mccutchen/go-httpbin/issues/259, a small refactor of the test suite to decouple app configuration from an in-process `*HTTPBin` instance.  Should be a no-op change.