### PR TITLE
build: fix static linking in distroless dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax = docker/dockerfile:1.3
-FROM golang:1.26.4 AS build
+FROM golang:1.26 AS build
 
 WORKDIR /go/src/github.com/mccutchen/go-httpbin
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax = docker/dockerfile:1.3
-FROM golang:1.26 AS build
+FROM golang:1.26.4 AS build
 
 WORKDIR /go/src/github.com/mccutchen/go-httpbin
 

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ build:
 	mkdir -p $(DIST_PATH)
 	GIT_COMMIT=$$(git describe --always --dirty 2>/dev/null || echo "unknown"); \
 	BUILD_DATE=$$(date -u +%Y-%m-%dT%H:%M:%SZ); \
-	CGO_ENABLED=0; \
+	CGO_ENABLED=0 \
 	go build -ldflags="-s -w -X main.commit=$$GIT_COMMIT -X main.buildDate=$$BUILD_DATE" -o $(DIST_PATH)/go-httpbin ./cmd/go-httpbin
 .PHONY: build
 


### PR DESCRIPTION
  ## Summary
  - Pin Docker build image to `golang:1.26.4` (was `golang:1.26`) for the latest stable Go.
  - Fix `Makefile` build target: drop the stray `;` after `CGO_ENABLED=0`. The semicolon made it a non-exported shell var, so `go
  build` defaulted to CGO enabled and produced a dynamically-linked binary — which fails on distroless with `exec /bin/go-httpbin:
  no such file or directory`. Now statically linked.