### PR TITLE
ci: update actions via pinact

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,7 +39,7 @@ jobs:
     - name: test
       run: make testci
 
-    - uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
+    - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
       if: ${{ matrix.go-version == 'stable' }}
       with:
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,7 +57,7 @@ jobs:
         with:
           go-version: 'stable'
 
-      - uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
+      - uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1
         with:
           version: latest
 
@@ -70,7 +70,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
+      - uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,19 +43,19 @@ jobs:
           # https://docs.zizmor.sh/audits/#cache-poisoning
           cache: false
       - uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
-      - uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
-      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
-      - uses: goreleaser/goreleaser-action@1a80836c5c9d9e5755a25cb59ec6f45a3b5f41a8 # v7.2.1
+      - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+      - uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2
         with:
           version: '~> v2'
           install-only: true
 
-      - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+      - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+      - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}

--- a/.pinact.yaml
+++ b/.pinact.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/suzuki-shunsuke/pinact/refs/heads/main/json-schema/pinact.json
+# pinact - https://github.com/suzuki-shunsuke/pinact
+version: 3
+min_age:
+  value: 7      # threshold in days
+  always: true  # also run the passive audit on every `pinact run` (extra GitHub API calls)

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ TEST_ARGS     ?= -race
 # 3rd party tools
 GOFUMPT     := go run mvdan.cc/gofumpt@v0.9.2
 GORELEASER  := go run github.com/goreleaser/goreleaser/v2@v2.15.2
+PINACT      := go run github.com/suzuki-shunsuke/pinact/v4/cmd/pinact@v4.1.0
 REFLEX      := go run github.com/cespare/reflex@v0.3.2
 REVIVE      := go run github.com/mgechev/revive@v1.15.0
 STATICCHECK := go run honnef.co/go/tools/cmd/staticcheck@2026.1
@@ -80,6 +81,9 @@ fmt:
 	$(GOFUMPT) -w .
 .PHONY: fmt
 
+update-actions:
+	GITHUB_TOKEN=$(shell gh auth token) $(PINACT) run --update
+.PHONY: update-actions
 
 # =============================================================================
 # run locally


### PR DESCRIPTION
- Adopt [pinact](https://github.com/suzuki-shunsuke/pinact) for managing GitHub Actions versions, configuring a minimum age of 7 days.
- Update all actions
- Bypass 7 day limit for `codecov/codecov-action` to pick up fix for https://github.com/codecov/codecov-action/issues/1956