### PR TITLE
handlers: tighten up `/redirect-to` target validation

### DIFF
--- a/httpbin/handlers.go
+++ b/httpbin/handlers.go
@@ -472,20 +472,11 @@ func (h *HTTPBin) RedirectTo(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// If we're given a URL that includes a domain name and we have a list of
-	// allowed domains, ensure that the domain is allowed.
-	//
-	// Note: This checks the hostname directly rather than using the net.URL's
-	// IsAbs() method, because IsAbs() will return false for URLs that omit
-	// the scheme but include a domain name, like "//evil.com" and it's
-	// important that we validate the domain in these cases as well.
-	if u.Hostname() != "" && len(h.AllowedRedirectDomains) > 0 {
-		if _, ok := h.AllowedRedirectDomains[u.Hostname()]; !ok {
-			// for this error message we do not use our standard JSON response
-			// because we want it to be more obviously human readable.
-			writeResponse(w, http.StatusForbidden, "text/plain", []byte(h.forbiddenRedirectError))
-			return
-		}
+	if !h.redirectAllowed(u) {
+		// for this error message we do not use our standard JSON response
+		// because we want it to be more obviously human readable.
+		writeResponse(w, http.StatusForbidden, "text/plain", []byte(h.forbiddenRedirectError))
+		return
 	}
 
 	statusCode := http.StatusFound
@@ -498,6 +489,22 @@ func (h *HTTPBin) RedirectTo(w http.ResponseWriter, r *http.Request) {
 	}
 
 	h.doRedirect(w, u.String(), statusCode)
+}
+
+// redirectAllowed checks whether the given redirect target is permitted.
+//
+// If a hostname allowlist is configured and the target is an absolute URL,
+// its hostname must be in the allowlist.
+//
+// Otherwise, the target must be either an absolute or root-relative URL.
+func (h *HTTPBin) redirectAllowed(target *url.URL) bool {
+	if len(h.AllowedRedirectDomains) > 0 {
+		if host := target.Hostname(); host != "" {
+			_, ok := h.AllowedRedirectDomains[host]
+			return ok
+		}
+	}
+	return target.IsAbs() || strings.HasPrefix(target.Path, "/")
 }
 
 // Cookies responds with the cookies in the incoming request

--- a/httpbin/handlers_test.go
+++ b/httpbin/handlers_test.go
@@ -1567,8 +1567,6 @@ func TestRedirectTo(t *testing.T) {
 
 		{"/redirect-to?url=/get", "/get", http.StatusFound},
 		{"/redirect-to?url=/get&status_code=307", "/get", http.StatusTemporaryRedirect},
-
-		{"/redirect-to?url=foo", "foo", http.StatusFound},
 	}
 
 	for _, test := range okTests {
@@ -1587,10 +1585,11 @@ func TestRedirectTo(t *testing.T) {
 	}{
 		{"/redirect-to", http.StatusBadRequest},                                               // missing url
 		{"/redirect-to?status_code=302", http.StatusBadRequest},                               // missing url
-		{"/redirect-to?url=foo&status_code=201", http.StatusBadRequest},                       // invalid status code
-		{"/redirect-to?url=foo&status_code=418", http.StatusBadRequest},                       // invalid status code
-		{"/redirect-to?url=foo&status_code=foo", http.StatusBadRequest},                       // invalid status code
+		{"/redirect-to?url=/get&status_code=201", http.StatusBadRequest},                      // invalid status code
+		{"/redirect-to?url=/get&status_code=418", http.StatusBadRequest},                      // invalid status code
+		{"/redirect-to?url=/get&status_code=/get", http.StatusBadRequest},                     // invalid status code
 		{"/redirect-to?url=http%3A%2F%2Ffoo%25%25bar&status_code=418", http.StatusBadRequest}, // invalid URL
+		{"/redirect-to?url=foo", http.StatusForbidden},                                        // relative target URL must be root-relative or is considered malicious
 	}
 	for _, test := range badTests {
 		t.Run("bad"+test.url, func(t *testing.T) {
@@ -1613,6 +1612,16 @@ func TestRedirectTo(t *testing.T) {
 
 		// See https://github.com/mccutchen/go-httpbin/issues/173
 		{"/redirect-to?url=//evil.com", http.StatusForbidden}, // missing scheme to attempt to bypass allowlist
+
+		// Percent-encoded scheme/host used to smuggle a disallowed domain
+		// past the allowlist check.
+		{"/redirect-to?url=http%3A%2F%2Fevil.com", http.StatusForbidden},       // single-encoded
+		{"/redirect-to?url=http%253A%252F%252Fevil.com", http.StatusForbidden}, // double-encoded
+
+		// Malicious requests from live httpbingo traffic
+		{"/redirect-to?url=http%253A//%255B%253A%253Affff%253A169.254.169.254%255D/latest/meta-data/", http.StatusForbidden},
+		{"/redirect-to?url=http%253A%252F%252F169.254.169.254%252Flatest%252Fmeta-data%252Fiam%252Fsecurity-credentials%252F", http.StatusForbidden},
+		{"/redirect-to?url=http%253A%252F%252Flocalhost%253A8080%252Factuator%252Fenv&status_code=302", http.StatusForbidden},
 	}
 	for _, test := range allowListTests {
 		t.Run("allowlist"+test.url, func(t *testing.T) {


### PR DESCRIPTION
Noticed some very malicious requests getting successful 302 responses from /redirect-to instead of the 403s I expected while peeking at live traffic to https://httpbingo.org, e.g.:

    /redirect-to?url=http%253A//%255B%253A%253Affff%253A169.254.169.254%255D/latest/meta-data/
    /redirect-to?url=http%253A%252F%252F169.254.169.254%252Flatest%252Fmeta-data%252Fiam%252Fsecurity-credentials%252F
    /redirect-to?url=http%253A%252F%252Flocalhost%253A8080%252Factuator%252Fenv&status_code=302

This tightens up the redirect target validation to require either an absolute or a root-relative URL.

**Note:** This is technically a breaking change.